### PR TITLE
feat: add multi-unit currency support (sat, usd, eur)

### DIFF
--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -1,0 +1,123 @@
+import 'package:intl/intl.dart';
+
+/// Utilidades para formatear montos y unidades en El Caju.
+///
+/// USD y EUR usan centavos (multiplicador 100).
+/// SAT y otras unidades usan valores enteros.
+
+class UnitFormatter {
+  /// Multiplicador para convertir a unidad base.
+  /// USD/EUR almacenan centavos, display en unidades.
+  static int getMultiplier(String unit) {
+    switch (unit.toLowerCase()) {
+      case 'usd':
+      case 'eur':
+        return 100; // centavos
+      default:
+        return 1;
+    }
+  }
+
+  /// Formatea un balance para display.
+  /// Ejemplo: 1000 sat → "1,000", 500 usd → "5.00"
+  static String formatBalance(BigInt amount, String unit) {
+    final multiplier = getMultiplier(unit);
+
+    if (multiplier == 100) {
+      // USD/EUR: mostrar con 2 decimales
+      final value = amount.toDouble() / 100;
+      return value.toStringAsFixed(2);
+    } else {
+      // SAT y otros: entero con separador de miles
+      return NumberFormat('#,###').format(amount.toInt());
+    }
+  }
+
+  /// Formatea un balance con su unidad.
+  /// Ejemplo: 1000 sat → "1,000 BTC", 500 usd → "5.00 USD"
+  static String formatBalanceWithUnit(BigInt amount, String unit) {
+    final formatted = formatBalance(amount, unit);
+    final label = getUnitLabel(unit);
+    return '$formatted $label';
+  }
+
+  /// Obtiene la etiqueta de display para una unidad.
+  /// sat → BTC, usd → USD, eur → EUR, msat → MSAT
+  static String getUnitLabel(String unit) {
+    switch (unit.toLowerCase()) {
+      case 'sat':
+        return 'BTC';
+      case 'usd':
+        return 'USD';
+      case 'eur':
+        return 'EUR';
+      case 'msat':
+        return 'MSAT';
+      default:
+        return unit.toUpperCase();
+    }
+  }
+
+  /// Convierte input del usuario a BigInt para la unidad.
+  /// Ejemplo: "5.00" USD → BigInt(500)
+  static BigInt parseUserInput(String input, String unit) {
+    final multiplier = getMultiplier(unit);
+
+    // Limpiar input
+    final cleaned = input.replaceAll(',', '').replaceAll(' ', '');
+
+    if (multiplier == 100) {
+      // USD/EUR: parsear como decimal
+      final value = double.tryParse(cleaned) ?? 0.0;
+      return BigInt.from((value * 100).round());
+    } else {
+      // SAT: parsear como entero
+      return BigInt.from(int.tryParse(cleaned) ?? 0);
+    }
+  }
+
+  /// Obtiene el nombre del host de un mint URL.
+  /// Ejemplo: 'https://mint.cubabitcoin.org' → 'cubabitcoin.org'
+  static String getMintDisplayName(String mintUrl) {
+    try {
+      final uri = Uri.parse(mintUrl);
+      var host = uri.host;
+
+      // Limpiar prefijos comunes
+      host = host.replaceFirst('mint.', '');
+      host = host.replaceFirst('www.', '');
+
+      return host;
+    } catch (e) {
+      return mintUrl;
+    }
+  }
+
+  /// Formatea una fecha relativa.
+  /// Ejemplo: hace 5 min, hace 2 h, ayer, 15 ene
+  static String formatRelativeDate(DateTime date) {
+    final now = DateTime.now();
+    final difference = now.difference(date);
+
+    if (difference.inSeconds < 60) {
+      return 'Ahora';
+    } else if (difference.inMinutes < 60) {
+      return 'Hace ${difference.inMinutes} min';
+    } else if (difference.inHours < 24) {
+      return 'Hace ${difference.inHours} h';
+    } else if (difference.inDays == 1) {
+      return 'Ayer';
+    } else if (difference.inDays < 7) {
+      return 'Hace ${difference.inDays} días';
+    } else {
+      return DateFormat('d MMM').format(date);
+    }
+  }
+
+  /// Convierte timestamp BigInt (unix seconds) a DateTime.
+  static DateTime timestampToDateTime(BigInt timestamp) {
+    return DateTime.fromMillisecondsSinceEpoch(
+      timestamp.toInt() * 1000,
+    );
+  }
+}

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -16,6 +16,8 @@ class SettingsProvider extends ChangeNotifier {
   static const _defaultMintKey = 'default_mint';
   static const _localeKey = 'locale';
   static const _pinEnabledKey = 'pin_enabled';
+  static const _activeUnitKey = 'active_unit';
+  static const _activeMintUrlKey = 'active_mint_url';
 
   // Estado interno
   bool _isInitialized = false;
@@ -24,6 +26,8 @@ class SettingsProvider extends ChangeNotifier {
   String? _pin;
   String _locale = 'es';
   String _defaultMint = 'https://mint.cubabitcoin.org';
+  String _activeUnit = 'sat';
+  String? _activeMintUrl;
 
   // Getters
   bool get isInitialized => _isInitialized;
@@ -32,6 +36,8 @@ class SettingsProvider extends ChangeNotifier {
   bool get hasPin => _pin != null && _pin!.isNotEmpty;
   String get locale => _locale;
   String get defaultMint => _defaultMint;
+  String get activeUnit => _activeUnit;
+  String? get activeMintUrl => _activeMintUrl;
 
   // ============================================================
   // INICIALIZACION
@@ -49,6 +55,8 @@ class SettingsProvider extends ChangeNotifier {
     _locale = _prefs?.getString(_localeKey) ?? 'es';
     _defaultMint = _prefs?.getString(_defaultMintKey) ?? 'https://mint.cubabitcoin.org';
     _pinEnabled = _prefs?.getBool(_pinEnabledKey) ?? false;
+    _activeUnit = _prefs?.getString(_activeUnitKey) ?? 'sat';
+    _activeMintUrl = _prefs?.getString(_activeMintUrlKey);
 
     // Cargar PIN si existe
     if (_pinEnabled) {
@@ -143,6 +151,28 @@ class SettingsProvider extends ChangeNotifier {
   }
 
   // ============================================================
+  // UNIDAD Y MINT ACTIVO
+  // ============================================================
+
+  /// Guarda la unidad activa (sat, usd, eur, etc.).
+  Future<void> setActiveUnit(String unit) async {
+    await _prefs?.setString(_activeUnitKey, unit);
+    _activeUnit = unit;
+    notifyListeners();
+  }
+
+  /// Guarda el mint activo.
+  Future<void> setActiveMintUrl(String? mintUrl) async {
+    if (mintUrl != null) {
+      await _prefs?.setString(_activeMintUrlKey, mintUrl);
+    } else {
+      await _prefs?.remove(_activeMintUrlKey);
+    }
+    _activeMintUrl = mintUrl;
+    notifyListeners();
+  }
+
+  // ============================================================
   // BORRAR WALLET
   // ============================================================
 
@@ -156,12 +186,16 @@ class SettingsProvider extends ChangeNotifier {
     // Resetear preferencias
     await _prefs?.setBool(_hasWalletKey, false);
     await _prefs?.setBool(_pinEnabledKey, false);
+    await _prefs?.remove(_activeUnitKey);
+    await _prefs?.remove(_activeMintUrlKey);
     // Mantener locale y defaultMint (preferencias de app, no de wallet)
 
     // Resetear estado
     _hasWallet = false;
     _pinEnabled = false;
     _pin = null;
+    _activeUnit = 'sat';
+    _activeMintUrl = null;
 
     notifyListeners();
   }
@@ -180,6 +214,8 @@ class SettingsProvider extends ChangeNotifier {
     _pin = null;
     _locale = 'es';
     _defaultMint = 'https://mint.cubabitcoin.org';
+    _activeUnit = 'sat';
+    _activeMintUrl = null;
 
     notifyListeners();
   }

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -17,122 +17,306 @@ class TokenInfo {
 }
 
 /// Provider que gestiona todas las operaciones del wallet Cashu.
-/// Capa intermedia entre la UI y cdk_flutter (Rust).
+/// Soporta múltiples unidades (sat, usd, eur) por mint.
+/// Usa múltiples instancias de Wallet compartiendo una sola DB.
 class WalletProvider extends ChangeNotifier {
-  MultiMintWallet? _multiWallet;
-  Wallet? _activeWallet;
   WalletDatabase? _db;
+  String? _mnemonic;
+
+  /// Mints conocidos con sus unidades soportadas.
+  /// Ejemplo: {'mint.cubabitcoin.org': ['sat', 'usd']}
+  final Map<String, List<String>> _mintUnits = {};
+
+  /// Wallets por mint:unidad (lazy loading).
+  /// Clave: 'mintUrl:unit', Ejemplo: 'https://mint.cubabitcoin.org:sat'
+  final Map<String, Wallet> _wallets = {};
+
+  /// Mint activo actualmente
   String? _activeMintUrl;
 
-  // Getters
-  bool get isInitialized => _multiWallet != null;
-  Wallet? get activeWallet => _activeWallet;
+  /// Unidad activa actualmente
+  String _activeUnit = 'sat';
+
+  // ============================================================
+  // GETTERS
+  // ============================================================
+
+  bool get isInitialized => _db != null && _mnemonic != null;
   String? get activeMintUrl => _activeMintUrl;
-  MultiMintWallet? get multiWallet => _multiWallet;
+  String get activeUnit => _activeUnit;
+
+  /// Unidades soportadas por el mint activo
+  List<String> get activeUnits => _mintUnits[_activeMintUrl] ?? ['sat'];
+
+  /// Wallet activo (mint + unidad actuales)
+  Wallet? get activeWallet {
+    if (_activeMintUrl == null) return null;
+    final key = '$_activeMintUrl:$_activeUnit';
+    return _wallets[key];
+  }
+
+  /// Todos los wallets creados (para verificación de proofs)
+  Iterable<Wallet> get allWallets => _wallets.values;
+
+  /// Lista de URLs de mints conocidos
+  List<String> get mintUrls => _mintUnits.keys.toList();
 
   // ============================================================
   // INICIALIZACION
   // ============================================================
 
-  /// Inicializa el wallet con un mnemonic.
-  /// MultiMintWallet carga automaticamente los mints guardados en la DB.
+  /// Inicializa el provider con un mnemonic.
+  /// Carga mints y unidades desde la información guardada.
   Future<void> initialize(String mnemonic) async {
+    _mnemonic = mnemonic;
+
     // Obtener directorio de documentos (path absoluto requerido)
     final dir = await getApplicationDocumentsDirectory();
     final dbPath = '${dir.path}/elcaju_wallet.sqlite';
 
-    // Crear base de datos (se crea automaticamente si no existe)
+    // Crear base de datos (se crea automáticamente si no existe)
     _db = await WalletDatabase.newInstance(path: dbPath);
 
-    // Crear multi-mint wallet (carga mints de DB automaticamente)
-    _multiWallet = await MultiMintWallet.newInstance(
+    // Verificar si es primera vez
+    // Creamos un wallet temporal para ver si hay mints guardados
+    final tempWallet = Wallet(
+      mintUrl: 'https://mint.cubabitcoin.org',
       unit: 'sat',
       mnemonic: mnemonic,
       db: _db!,
     );
 
-    // Verificar si es primera vez (sin mints)
-    final mints = await _multiWallet!.listMints();
+    // Intentar obtener balance - si tiene datos, ya fue inicializado antes
+    try {
+      final balance = await tempWallet.balance();
 
-    if (mints.isEmpty) {
-      // Primera vez: agregar mint por defecto
+      // Si llegamos aquí, el mint existe en la DB
+      // Agregar mint por defecto con sus unidades
+      await _detectAndAddMint('https://mint.cubabitcoin.org');
+
+      // Guardar el wallet
+      _wallets['https://mint.cubabitcoin.org:sat'] = tempWallet;
+
+      // Establecer como activo
+      _activeMintUrl = 'https://mint.cubabitcoin.org';
+      _activeUnit = 'sat';
+
+      // Si tiene balance > 0, definitivamente existía
+      if (balance > BigInt.zero) {
+        debugPrint('Wallet restaurado con balance: $balance');
+      }
+    } catch (e) {
+      // Primera vez - agregar mint por defecto
       await addMint('https://mint.cubabitcoin.org');
-      await setActiveMint('https://mint.cubabitcoin.org');
-    } else {
-      // Restauracion: usar primer mint como activo
-      await setActiveMint(mints.first.url);
     }
 
     notifyListeners();
   }
 
-  /// Detecta si es primera vez (sin mints en la DB).
-  /// Usar despues de initialize().
-  Future<bool> isFirstTime() async {
-    if (_multiWallet == null) return true;
-    final mints = await _multiWallet!.listMints();
-    return mints.isEmpty;
+  /// Detecta si es primera vez (sin mints conocidos).
+  bool isFirstTime() {
+    return _mintUnits.isEmpty;
   }
 
   /// Genera un nuevo mnemonic de 12 palabras BIP39.
-  /// Funcion global de cdk_flutter.
   String generateNewMnemonic() {
     return generateMnemonic();
+  }
+
+  // ============================================================
+  // WALLET MANAGEMENT (Lazy Loading)
+  // ============================================================
+
+  /// Obtiene o crea un wallet para un mint y unidad específicos.
+  /// Implementa lazy loading - solo crea el wallet cuando se necesita.
+  Future<Wallet> getWallet(String mintUrl, String unit) async {
+    if (_db == null || _mnemonic == null) {
+      throw Exception('WalletProvider no inicializado');
+    }
+
+    final key = '$mintUrl:$unit';
+
+    if (!_wallets.containsKey(key)) {
+      _wallets[key] = Wallet(
+        mintUrl: mintUrl,
+        unit: unit,
+        mnemonic: _mnemonic!,
+        db: _db!,
+      );
+    }
+
+    return _wallets[key]!;
+  }
+
+  /// Obtiene el wallet activo, creándolo si no existe.
+  Future<Wallet> getActiveWallet() async {
+    if (_activeMintUrl == null) {
+      throw Exception('No hay mint activo');
+    }
+    return await getWallet(_activeMintUrl!, _activeUnit);
   }
 
   // ============================================================
   // MULTI-MINT OPERATIONS
   // ============================================================
 
-  /// Agrega un mint. Idempotente (no error si ya existe).
+  /// Detecta las unidades soportadas por un mint y las registra.
+  /// Usa mintInfo.nuts.nut04 (MintMethodSettings) para obtener las unidades.
+  Future<List<String>> _detectAndAddMint(String mintUrl) async {
+    try {
+      // Obtener info del mint (función global de cdk_flutter)
+      final mintInfo = await getMintInfo(mintUrl: mintUrl);
+
+      // Extraer unidades de nut04 (mint methods)
+      final units = <String>{};
+
+      // nut04 contiene los métodos de mint con sus unidades
+      final nut04 = mintInfo.nuts.nut04;
+      for (final method in nut04.methods) {
+        units.add(method.unit);
+      }
+
+      // Si no hay unidades detectadas, usar 'sat' por defecto
+      final unitList = units.isEmpty ? ['sat'] : units.toList();
+
+      // Ordenar: sat primero, luego alfabético
+      unitList.sort((a, b) {
+        if (a == 'sat') return -1;
+        if (b == 'sat') return 1;
+        return a.compareTo(b);
+      });
+
+      _mintUnits[mintUrl] = unitList;
+      return unitList;
+    } catch (e) {
+      debugPrint('Error detectando unidades de $mintUrl: $e');
+      // Fallback a sat
+      _mintUnits[mintUrl] = ['sat'];
+      return ['sat'];
+    }
+  }
+
+  /// Agrega un mint, detectando automáticamente sus unidades.
   Future<void> addMint(String mintUrl) async {
-    if (_multiWallet == null) return;
-    await _multiWallet!.addMint(mintUrl: mintUrl);
+    if (_db == null || _mnemonic == null) {
+      throw Exception('WalletProvider no inicializado');
+    }
+
+    // Detectar unidades
+    final units = await _detectAndAddMint(mintUrl);
+
+    // Crear wallet para la primera unidad
+    await getWallet(mintUrl, units.first);
+
+    // Activar si es el primer mint
+    _activeMintUrl ??= mintUrl;
+    if (_activeMintUrl == mintUrl) {
+      _activeUnit = units.first;
+    }
+
     notifyListeners();
   }
 
-  /// Lista los mints conectados.
-  /// Retorna List de Mint con propiedades: url, balance, info.
-  Future<List<Mint>> listMints() async {
-    if (_multiWallet == null) return [];
-    return await _multiWallet!.listMints();
+  /// Refresca la información de un mint (keysets, unidades).
+  /// Útil para detectar nuevas unidades agregadas por el mint.
+  Future<List<String>> refreshMint(String mintUrl) async {
+    final units = await _detectAndAddMint(mintUrl);
+    notifyListeners();
+    return units;
   }
 
-  /// Obtiene las URLs de los mints como lista de Strings.
-  Future<List<String>> getMintUrls() async {
-    final mints = await listMints();
-    return mints.map((m) => m.url).toList();
+  /// Obtiene las unidades soportadas por un mint.
+  List<String> getUnitsForMint(String mintUrl) {
+    return _mintUnits[mintUrl] ?? ['sat'];
   }
 
-  /// Remueve un mint. Lanza error si balance > 0.
+  /// Lista los mints conocidos con sus unidades.
+  Map<String, List<String>> listMintsWithUnits() {
+    return Map.unmodifiable(_mintUnits);
+  }
+
+  /// Remueve un mint y todos sus wallets asociados.
+  /// Nota: Si hay balance, el usuario puede recuperarlo después con restore (NUT-13).
   Future<void> removeMint(String mintUrl) async {
-    if (_multiWallet == null) return;
-    await _multiWallet!.removeMint(mintUrl: mintUrl);
+    // Eliminar wallets de este mint
+    final keysToRemove = _wallets.keys
+        .where((key) => key.startsWith('$mintUrl:'))
+        .toList();
+    for (final key in keysToRemove) {
+      _wallets.remove(key);
+    }
+
+    // Eliminar de mints conocidos
+    _mintUnits.remove(mintUrl);
 
     // Si era el mint activo, cambiar a otro
     if (_activeMintUrl == mintUrl) {
-      final mints = await listMints();
-      if (mints.isNotEmpty) {
-        await setActiveMint(mints.first.url);
+      if (_mintUnits.isNotEmpty) {
+        final newMint = _mintUnits.keys.first;
+        _activeMintUrl = newMint;
+        _activeUnit = _mintUnits[newMint]!.first;
       } else {
-        _activeWallet = null;
         _activeMintUrl = null;
+        _activeUnit = 'sat';
       }
     }
 
     notifyListeners();
   }
 
-  /// Cambia el mint activo.
-  /// Usa createOrGetWallet para garantizar que exista.
-  Future<void> setActiveMint(String mintUrl) async {
-    if (_multiWallet == null) return;
+  // ============================================================
+  // ACTIVE MINT/UNIT SELECTION
+  // ============================================================
 
-    // createOrGetWallet nunca retorna null (crea si no existe)
-    _activeWallet = await _multiWallet!.createOrGetWallet(mintUrl: mintUrl);
+  /// Cambia el mint activo.
+  Future<void> setActiveMint(String mintUrl) async {
+    if (!_mintUnits.containsKey(mintUrl)) {
+      throw Exception('Mint no conocido: $mintUrl');
+    }
+
     _activeMintUrl = mintUrl;
 
+    // Si la unidad activa no está soportada por este mint, cambiar a la primera
+    final units = _mintUnits[mintUrl]!;
+    if (!units.contains(_activeUnit)) {
+      _activeUnit = units.first;
+    }
+
+    // Asegurar que el wallet existe
+    await getWallet(mintUrl, _activeUnit);
+
     notifyListeners();
+  }
+
+  /// Cambia la unidad activa.
+  Future<void> setActiveUnit(String unit) async {
+    if (_activeMintUrl == null) return;
+
+    final units = _mintUnits[_activeMintUrl]!;
+    if (!units.contains(unit)) {
+      throw Exception('Unidad $unit no soportada por el mint activo');
+    }
+
+    _activeUnit = unit;
+
+    // Asegurar que el wallet existe
+    await getWallet(_activeMintUrl!, unit);
+
+    notifyListeners();
+  }
+
+  /// Cicla a la siguiente unidad del mint activo.
+  /// Orden: sat → usd → eur → sat ...
+  Future<void> cycleUnit() async {
+    if (_activeMintUrl == null) return;
+
+    final units = activeUnits;
+    if (units.length <= 1) return;
+
+    final currentIndex = units.indexOf(_activeUnit);
+    final nextIndex = (currentIndex + 1) % units.length;
+
+    await setActiveUnit(units[nextIndex]);
   }
 
   // ============================================================
@@ -141,34 +325,47 @@ class WalletProvider extends ChangeNotifier {
 
   /// Stream de balance del wallet activo (reactivo).
   Stream<BigInt>? streamBalance() {
-    return _activeWallet?.streamBalance();
+    return activeWallet?.streamBalance();
   }
 
-  /// Stream de balance total de todos los mints.
-  /// Nota: En MultiMintWallet el método es streamBalance() (no streamTotalBalance).
-  Stream<BigInt>? streamTotalBalance() {
-    return _multiWallet?.streamBalance();
-  }
-
-  /// Obtiene el balance total de todos los mints.
-  Future<BigInt> getTotalBalance() async {
-    if (_multiWallet == null) return BigInt.zero;
-    return await _multiWallet!.totalBalance();
-  }
-
-  /// Obtiene el balance de un mint especifico.
-  Future<BigInt> getBalanceForMint(String mintUrl) async {
-    if (_multiWallet == null) return BigInt.zero;
-    final wallet = await _multiWallet!.getWallet(mintUrl: mintUrl);
+  /// Obtiene el balance del wallet activo.
+  Future<BigInt> getBalance() async {
+    final wallet = activeWallet;
     if (wallet == null) return BigInt.zero;
     return await wallet.balance();
+  }
+
+  /// Obtiene el balance de un mint en una unidad específica.
+  Future<BigInt> getBalanceForMintUnit(String mintUrl, String unit) async {
+    final key = '$mintUrl:$unit';
+    final wallet = _wallets[key];
+    if (wallet == null) {
+      // Crear wallet si no existe
+      final newWallet = await getWallet(mintUrl, unit);
+      return await newWallet.balance();
+    }
+    return await wallet.balance();
+  }
+
+  /// Obtiene el balance total de un mint (todas las unidades).
+  /// Retorna Map con unit como clave y balance como valor.
+  Future<Map<String, BigInt>> getBalancesForMint(String mintUrl) async {
+    final units = _mintUnits[mintUrl] ?? [];
+    final balances = <String, BigInt>{};
+
+    for (final unit in units) {
+      balances[unit] = await getBalanceForMintUnit(mintUrl, unit);
+    }
+
+    return balances;
   }
 
   // ============================================================
   // RECEIVE (Recibir tokens Cashu)
   // ============================================================
 
-  /// Parsea un token sin reclamarlo. Retorna null si invalido.
+  /// Parsea un token sin reclamarlo. Retorna null si inválido.
+  /// Nota: Token no contiene información de unidad.
   TokenInfo? parseToken(String encodedToken) {
     try {
       final token = Token.parse(encoded: encodedToken);
@@ -178,42 +375,76 @@ class WalletProvider extends ChangeNotifier {
         encoded: token.encoded,
       );
     } catch (e) {
-      // Token.parse lanza excepcion si invalido
       return null;
     }
   }
 
-  /// Reclama un token Cashu. Retorna monto recibido.
+  /// Reclama un token Cashu usando la unidad activa.
+  /// Si el mint del token es diferente al activo, lo agrega y cambia a él.
+  /// Retorna monto recibido.
   Future<BigInt> receiveToken(String encodedToken) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
+    // Parsear token
+    final tokenInfo = parseToken(encodedToken);
+    if (tokenInfo == null) {
+      throw Exception('Token inválido');
     }
 
-    // Parsear token (lanza excepcion si invalido)
-    final token = Token.parse(encoded: encodedToken);
+    final tokenMint = tokenInfo.mintUrl;
 
-    // Reclamar token
-    final amount = await _activeWallet!.receive(token: token);
+    // Verificar si conocemos este mint
+    if (!_mintUnits.containsKey(tokenMint)) {
+      // Agregar el mint automáticamente
+      await addMint(tokenMint);
+    }
+
+    // Cambiar al mint del token (mantener unidad activa si es soportada)
+    _activeMintUrl = tokenMint;
+
+    // Verificar si la unidad activa es soportada por este mint
+    final units = _mintUnits[tokenMint]!;
+    if (!units.contains(_activeUnit)) {
+      // Cambiar a la primera unidad soportada
+      _activeUnit = units.first;
+    }
+
+    // Obtener wallet correcto
+    final wallet = await getWallet(tokenMint, _activeUnit);
+
+    // Parsear y reclamar
+    final token = Token.parse(encoded: encodedToken);
+    final amount = await wallet.receive(token: token);
 
     notifyListeners();
     return amount;
   }
 
-  /// Reclama un token P2PK (bloqueado a una clave publica).
-  /// Requiere la clave privada correspondiente para firmar.
-  /// [signingKeys] lista de claves privadas en formato hex.
+  /// Reclama un token P2PK (bloqueado a una clave pública).
   Future<BigInt> receiveP2pkToken(
     String encodedToken,
     List<String> signingKeys,
   ) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
+    final tokenInfo = parseToken(encodedToken);
+    if (tokenInfo == null) {
+      throw Exception('Token inválido');
     }
 
+    // Cambiar al mint del token
+    if (!_mintUnits.containsKey(tokenInfo.mintUrl)) {
+      await addMint(tokenInfo.mintUrl);
+    }
+
+    _activeMintUrl = tokenInfo.mintUrl;
+
+    // Verificar si la unidad activa es soportada
+    final units = _mintUnits[tokenInfo.mintUrl]!;
+    if (!units.contains(_activeUnit)) {
+      _activeUnit = units.first;
+    }
+
+    final wallet = await getWallet(tokenInfo.mintUrl, _activeUnit);
     final token = Token.parse(encoded: encodedToken);
 
-    // Reclamar con claves de firma para P2PK
-    final amount = await _activeWallet!.receive(
+    final amount = await wallet.receive(
       token: token,
       opts: ReceiveOptions(signingKeys: signingKeys),
     );
@@ -226,35 +457,26 @@ class WalletProvider extends ChangeNotifier {
   // SEND (Enviar tokens Cashu)
   // ============================================================
 
-  /// Prepara un envio (reserva proofs, calcula fees).
-  /// Retorna PreparedSend para confirmar o cancelar.
+  /// Prepara un envío (reserva proofs, calcula fees).
   Future<PreparedSend> prepareSend(BigInt amount) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
-    return await _activeWallet!.prepareSend(amount: amount);
+    final wallet = await getActiveWallet();
+    return await wallet.prepareSend(amount: amount);
   }
 
-  /// Prepara un envio P2PK (bloqueado a una clave publica).
-  /// Solo el poseedor de la clave privada correspondiente puede reclamar.
-  /// [pubkey] clave publica del receptor en formato hex.
+  /// Prepara un envío P2PK (bloqueado a una clave pública).
   Future<PreparedSend> prepareSendP2pk(BigInt amount, String pubkey) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
-    return await _activeWallet!.prepareSend(
+    final wallet = await getActiveWallet();
+    return await wallet.prepareSend(
       amount: amount,
       opts: SendOptions(pubkey: pubkey),
     );
   }
 
-  /// Confirma un envio preparado y retorna el token encoded.
+  /// Confirma un envío preparado y retorna el token encoded.
   Future<String> confirmSend(PreparedSend prepared, String? memo) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
+    final wallet = await getActiveWallet();
 
-    final token = await _activeWallet!.send(
+    final token = await wallet.send(
       send: prepared,
       memo: memo,
       includeMemo: memo != null && memo.isNotEmpty,
@@ -264,22 +486,19 @@ class WalletProvider extends ChangeNotifier {
     return token.encoded;
   }
 
-  /// Cancela un envio preparado (libera proofs reservados).
+  /// Cancela un envío preparado (libera proofs reservados).
   Future<void> cancelSend(PreparedSend prepared) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
-    await _activeWallet!.cancelSend(send: prepared);
+    final wallet = await getActiveWallet();
+    await wallet.cancelSend(send: prepared);
   }
 
-  /// Metodo de conveniencia: prepara y confirma en un solo paso.
+  /// Método de conveniencia: prepara y confirma en un solo paso.
   Future<String> sendTokens(BigInt amount, String? memo) async {
     final prepared = await prepareSend(amount);
     return await confirmSend(prepared, memo);
   }
 
-  /// Envia tokens P2PK (bloqueados a una clave publica).
-  /// Solo el poseedor de la clave privada correspondiente puede reclamar.
+  /// Envía tokens P2PK.
   Future<String> sendTokensP2pk(
     BigInt amount,
     String pubkey,
@@ -293,15 +512,15 @@ class WalletProvider extends ChangeNotifier {
   // MINT (Depositar via Lightning)
   // ============================================================
 
-  /// Inicia un deposito via Lightning.
+  /// Inicia un depósito via Lightning.
   /// Retorna Stream con estados: unpaid -> paid -> issued.
-  /// quote.request contiene el invoice BOLT11 a pagar.
   Stream<MintQuote> mintTokens(BigInt amount, String? description) {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
+    final wallet = activeWallet;
+    if (wallet == null) {
+      throw Exception('No hay wallet activo');
     }
 
-    return _activeWallet!.mint(
+    return wallet.mint(
       amount: amount,
       description: description,
     );
@@ -312,22 +531,15 @@ class WalletProvider extends ChangeNotifier {
   // ============================================================
 
   /// Obtiene quote para pagar un invoice BOLT11.
-  /// MeltQuote contiene: amount, feeReserve, expiry.
   Future<MeltQuote> getMeltQuote(String bolt11Invoice) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
-    return await _activeWallet!.meltQuote(request: bolt11Invoice);
+    final wallet = await getActiveWallet();
+    return await wallet.meltQuote(request: bolt11Invoice);
   }
 
   /// Ejecuta el pago del invoice.
-  /// Retorna monto total pagado (incluyendo fee).
   Future<BigInt> melt(MeltQuote quote) async {
-    if (_activeWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
-
-    final totalPaid = await _activeWallet!.melt(quote: quote);
+    final wallet = await getActiveWallet();
+    final totalPaid = await wallet.melt(quote: quote);
     notifyListeners();
     return totalPaid;
   }
@@ -337,146 +549,171 @@ class WalletProvider extends ChangeNotifier {
   // ============================================================
 
   /// Obtiene transacciones del wallet activo.
-  /// Filtrable por direccion: incoming, outgoing.
   Future<List<Transaction>> getTransactions({
     TransactionDirection? direction,
   }) async {
-    if (_activeWallet == null) return [];
-    return await _activeWallet!.listTransactions(direction: direction);
+    final wallet = activeWallet;
+    if (wallet == null) return [];
+    return await wallet.listTransactions(direction: direction);
   }
 
-  /// Obtiene transacciones de todos los mints.
+  /// Obtiene transacciones de todos los wallets.
   Future<List<Transaction>> getAllTransactions({
     TransactionDirection? direction,
   }) async {
-    if (_multiWallet == null) return [];
-    return await _multiWallet!.listTransactions(direction: direction);
+    final allTransactions = <Transaction>[];
+
+    for (final wallet in _wallets.values) {
+      try {
+        final txs = await wallet.listTransactions(direction: direction);
+        allTransactions.addAll(txs);
+      } catch (e) {
+        debugPrint('Error obteniendo transacciones: $e');
+      }
+    }
+
+    // Ordenar por timestamp (más reciente primero)
+    allTransactions.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+
+    return allTransactions;
+  }
+
+  // ============================================================
+  // VERIFICACION DE PROOFS
+  // ============================================================
+
+  /// Verifica proofs pendientes en todos los wallets.
+  /// Llamar en background al iniciar la app.
+  Future<void> checkPendingTransactions() async {
+    for (final wallet in _wallets.values) {
+      try {
+        await wallet.checkPendingTransactions();
+      } catch (e) {
+        // Silencioso - puede fallar offline
+        debugPrint('Check pending failed: $e');
+      }
+    }
+  }
+
+  /// Verifica si un token específico fue gastado.
+  Future<bool> isTokenSpent(String encodedToken) async {
+    final wallet = activeWallet;
+    if (wallet == null) return false;
+
+    final token = Token.parse(encoded: encodedToken);
+    return await wallet.isTokenSpent(token: token);
   }
 
   // ============================================================
   // RESTORE (NUT-13 + NUT-09)
   // ============================================================
 
-  /// Escanea un mint específico para recuperar tokens usando NUT-13.
-  /// Retorna el balance encontrado.
-  Future<BigInt> restoreFromMint(String mintUrl) async {
-    if (_multiWallet == null) {
-      throw Exception('Wallet no inicializado');
-    }
-
-    // Obtener o crear wallet para este mint
-    final wallet = await _multiWallet!.createOrGetWallet(mintUrl: mintUrl);
-
-    // Obtener balance antes del restore
-    final balanceBefore = await wallet.balance();
-
-    // Ejecutar restore (NUT-13 + NUT-09)
-    await wallet.restore();
-
-    // Obtener balance después
-    final balanceAfter = await wallet.balance();
-
-    // Calcular tokens recuperados
-    final recovered = balanceAfter - balanceBefore;
-
-    notifyListeners();
-    return recovered;
-  }
-
-  /// Escanea todos los mints conectados para recuperar tokens.
-  /// Retorna mapa de mint -> balance recuperado.
-  Future<Map<String, BigInt>> restoreAllMints() async {
-    if (_multiWallet == null) {
-      throw Exception('Wallet no inicializado');
+  /// Escanea un mint para todas sus unidades usando NUT-13.
+  /// Retorna Map con unit como clave y balance recuperado como valor.
+  Future<Map<String, BigInt>> restoreFromMint(String mintUrl) async {
+    if (_db == null || _mnemonic == null) {
+      throw Exception('WalletProvider no inicializado');
     }
 
     final results = <String, BigInt>{};
-    final mints = await _multiWallet!.listMints();
+    final units = _mintUnits[mintUrl] ?? ['sat'];
 
-    for (final mint in mints) {
+    for (final unit in units) {
       try {
-        final recovered = await restoreFromMint(mint.url);
-        results[mint.url] = recovered;
+        final wallet = await getWallet(mintUrl, unit);
+        final balanceBefore = await wallet.balance();
+
+        await wallet.restore();
+
+        final balanceAfter = await wallet.balance();
+        final recovered = balanceAfter - balanceBefore;
+        results[unit] = recovered;
       } catch (e) {
-        // Si falla un mint, continuar con los demás
-        debugPrint('Error restaurando ${mint.url}: $e');
-        results[mint.url] = BigInt.from(-1); // Indica error
+        debugPrint('Error restaurando $mintUrl:$unit: $e');
+        results[unit] = BigInt.from(-1); // Indica error
       }
+    }
+
+    notifyListeners();
+    return results;
+  }
+
+  /// Escanea todos los mints conocidos para recuperar tokens.
+  Future<Map<String, Map<String, BigInt>>> restoreAllMints() async {
+    final results = <String, Map<String, BigInt>>{};
+
+    for (final mintUrl in _mintUnits.keys) {
+      results[mintUrl] = await restoreFromMint(mintUrl);
     }
 
     return results;
   }
 
-  /// Restaura tokens usando un mnemonic diferente y los transfiere al wallet actual.
-  /// Útil para recuperar tokens de otra semilla.
-  ///
-  /// Flujo:
-  /// 1. Crear wallet temporal con el mnemonic proporcionado
-  /// 2. Escanear cada mint para recuperar tokens
-  /// 3. Si encuentra tokens, enviarlos como token Cashu
-  /// 4. Reclamar esos tokens en el wallet actual
-  /// 5. Retornar total recuperado
-  Future<BigInt> restoreWithMnemonic(String mnemonic, List<String> mintUrls) async {
-    if (_multiWallet == null || _activeWallet == null) {
-      throw Exception('Wallet no inicializado');
+  /// Restaura tokens usando otro mnemonic y los transfiere al wallet actual.
+  Future<BigInt> restoreWithMnemonic(
+    String mnemonic,
+    List<String> mintUrls,
+  ) async {
+    if (_db == null || _mnemonic == null) {
+      throw Exception('WalletProvider no inicializado');
     }
 
     BigInt totalRecovered = BigInt.zero;
 
-    // Normalizar mnemonic (espacios simples, minúsculas)
-    final normalizedMnemonic = mnemonic.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+    // Normalizar mnemonic
+    final normalizedMnemonic =
+        mnemonic.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
 
-    // Crear DB temporal para el wallet de recuperación
+    // Crear DB temporal
     final dir = await getApplicationDocumentsDirectory();
-    final tempDbPath = '${dir.path}/temp_restore_${DateTime.now().millisecondsSinceEpoch}.sqlite';
+    final tempDbPath =
+        '${dir.path}/temp_restore_${DateTime.now().millisecondsSinceEpoch}.sqlite';
 
     WalletDatabase? tempDb;
 
     try {
-      // Crear base de datos temporal
       tempDb = await WalletDatabase.newInstance(path: tempDbPath);
 
       for (final mintUrl in mintUrls) {
-        try {
-          // Crear wallet temporal para este mint
-          final tempWallet = Wallet(
-            mintUrl: mintUrl,
-            unit: 'sat',
-            mnemonic: normalizedMnemonic,
-            db: tempDb,
-          );
+        // Obtener unidades del mint
+        final units = _mintUnits[mintUrl] ?? ['sat'];
 
-          // Escanear el mint (NUT-13 + NUT-09)
-          await tempWallet.restore();
-
-          // Verificar si encontró balance
-          final tempBalance = await tempWallet.balance();
-
-          if (tempBalance > BigInt.zero) {
-            // Preparar envío de todo el balance
-            final prepared = await tempWallet.prepareSend(amount: tempBalance);
-
-            // Crear token
-            final token = await tempWallet.send(
-              send: prepared,
-              memo: 'Recuperación El Caju',
-              includeMemo: true,
+        for (final unit in units) {
+          try {
+            // Crear wallet temporal
+            final tempWallet = Wallet(
+              mintUrl: mintUrl,
+              unit: unit,
+              mnemonic: normalizedMnemonic,
+              db: tempDb,
             );
 
-            // Asegurar que tenemos wallet para este mint en nuestro wallet actual
-            final ourWallet = await _multiWallet!.createOrGetWallet(mintUrl: mintUrl);
+            // Escanear
+            await tempWallet.restore();
+            final tempBalance = await tempWallet.balance();
 
-            // Reclamar el token en nuestro wallet
-            final received = await ourWallet.receive(token: token);
-            totalRecovered += received;
+            if (tempBalance > BigInt.zero) {
+              // Enviar todo el balance
+              final prepared =
+                  await tempWallet.prepareSend(amount: tempBalance);
+              final token = await tempWallet.send(
+                send: prepared,
+                memo: 'Recuperación El Caju',
+                includeMemo: true,
+              );
+
+              // Reclamar en nuestro wallet
+              final ourWallet = await getWallet(mintUrl, unit);
+              final received = await ourWallet.receive(token: token);
+              totalRecovered += received;
+            }
+          } catch (e) {
+            debugPrint('Error restaurando $mintUrl:$unit: $e');
           }
-        } catch (e) {
-          debugPrint('Error restaurando desde $mintUrl: $e');
-          // Continuar con el siguiente mint
         }
       }
     } finally {
-      // Limpiar: cerrar y borrar DB temporal
+      // Limpiar DB temporal
       tempDb = null;
       try {
         final tempFile = File(tempDbPath);
@@ -487,6 +724,7 @@ class WalletProvider extends ChangeNotifier {
         debugPrint('Error limpiando DB temporal: $e');
       }
     }
+
     notifyListeners();
     return totalRecovered;
   }
@@ -496,21 +734,19 @@ class WalletProvider extends ChangeNotifier {
   // ============================================================
 
   /// Borra la base de datos SQLite del wallet.
-  /// Debe llamarse ANTES de borrar el mnemonic en SettingsProvider.
-  /// Retorna true si se borró correctamente.
   Future<bool> deleteDatabase() async {
     try {
-      // Limpiar referencias internas primero
-      _multiWallet = null;
-      _activeWallet = null;
+      // Limpiar referencias
+      _wallets.clear();
+      _mintUnits.clear();
       _activeMintUrl = null;
+      _activeUnit = 'sat';
+      _mnemonic = null;
       _db = null;
 
-      // Obtener path de la base de datos
+      // Borrar archivo
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}/elcaju_wallet.sqlite';
-
-      // Borrar archivo si existe
       final dbFile = File(dbPath);
       if (await dbFile.exists()) {
         await dbFile.delete();
@@ -525,11 +761,12 @@ class WalletProvider extends ChangeNotifier {
   }
 
   /// Resetea el estado del provider (sin borrar la DB).
-  /// Útil para logout sin borrar datos.
   void reset() {
-    _multiWallet = null;
-    _activeWallet = null;
+    _wallets.clear();
+    _mintUnits.clear();
     _activeMintUrl = null;
+    _activeUnit = 'sat';
+    _mnemonic = null;
     _db = null;
     notifyListeners();
   }

--- a/lib/screens/5_send/share_token_screen.dart
+++ b/lib/screens/5_send/share_token_screen.dart
@@ -7,6 +7,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:cdk_flutter/cdk_flutter.dart' as cdk;
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';
+import '../../core/utils/formatters.dart';
 import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/common/primary_button.dart';
@@ -14,7 +15,7 @@ import '../../widgets/common/primary_button.dart';
 /// Pantalla para compartir el token Cashu generado
 class ShareTokenScreen extends StatefulWidget {
   final String token;
-  final int amount;
+  final BigInt amount;
   final String unit;
   final String? memo;
 
@@ -185,10 +186,13 @@ class _ShareTokenScreenState extends State<ShareTokenScreen> {
   }
 
   Widget _buildAmountDisplay() {
+    final formattedAmount = UnitFormatter.formatBalance(widget.amount, widget.unit);
+    final unitLabel = UnitFormatter.getUnitLabel(widget.unit);
+
     return Column(
       children: [
         Text(
-          '${widget.amount} ${widget.unit}',
+          '$formattedAmount $unitLabel',
           style: const TextStyle(
             fontFamily: 'Inter',
             fontSize: 36,
@@ -483,10 +487,13 @@ class _ShareTokenScreenState extends State<ShareTokenScreen> {
         ? '\n"${widget.memo}"'
         : '';
 
+    final formattedAmount = UnitFormatter.formatBalance(widget.amount, widget.unit);
+    final unitLabel = UnitFormatter.getUnitLabel(widget.unit);
+
     await SharePlus.instance.share(
       ShareParams(
-        text: '${widget.amount} ${widget.unit}$memo\n\n${widget.token}',
-        subject: 'Token Cashu - ${widget.amount} ${widget.unit}',
+        text: '$formattedAmount $unitLabel$memo\n\n${widget.token}',
+        subject: 'Token Cashu - $formattedAmount $unitLabel',
       ),
     );
   }

--- a/lib/screens/6_mint/invoice_screen.dart
+++ b/lib/screens/6_mint/invoice_screen.dart
@@ -7,6 +7,7 @@ import 'package:lucide_icons/lucide_icons.dart';
 import 'package:cdk_flutter/cdk_flutter.dart' hide WalletProvider;
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';
+import '../../core/utils/formatters.dart';
 import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/effects/cashu_confetti.dart';
@@ -17,7 +18,7 @@ enum MintStatus { loading, unpaid, paid, issued, error }
 
 /// Pantalla para mostrar el invoice generado y esperar el pago
 class InvoiceScreen extends StatefulWidget {
-  final int amount;
+  final BigInt amount;
   final String unit;
   final String? description;
 
@@ -57,7 +58,7 @@ class _InvoiceScreenState extends State<InvoiceScreen> {
 
     try {
       final mintStream = walletProvider.mintTokens(
-        BigInt.from(widget.amount),
+        widget.amount,
         widget.description,
       );
 
@@ -116,7 +117,7 @@ class _InvoiceScreenState extends State<InvoiceScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              '+${widget.amount} ${widget.unit} depositados',
+              '+${UnitFormatter.formatBalance(widget.amount, widget.unit)} ${UnitFormatter.getUnitLabel(widget.unit)} depositados',
             ),
             backgroundColor: AppColors.success,
             duration: const Duration(seconds: 3),
@@ -320,10 +321,13 @@ class _InvoiceScreenState extends State<InvoiceScreen> {
   }
 
   Widget _buildHeader() {
+    final formattedAmount = UnitFormatter.formatBalance(widget.amount, widget.unit);
+    final unitLabel = UnitFormatter.getUnitLabel(widget.unit);
+
     return Column(
       children: [
         Text(
-          'Depositar ${widget.amount} ${widget.unit}',
+          'Depositar $formattedAmount $unitLabel',
           style: const TextStyle(
             fontFamily: 'Inter',
             fontSize: 24,


### PR DESCRIPTION
- Refactor WalletProvider to support multiple units per mint                                                                                          
- Add lazy loading of Wallet instances per mint:unit                                                                                                  
- Add unit cycling on HomeScreen (tap to switch sat/usd/eur)                                                                                          
- Update MintsScreen to show balance per unit with refresh                                                                                            
- Update Send/Receive/Mint/Melt screens to use active unit                                                                                            
- Add UnitFormatter utility for consistent formatting                                                                                                 
- Persist active unit in SettingsProvider                                                                                                             
- Add background proof verification on app start"   