### PR TITLE
fix: resolve overlapping in screens with keyboard

### DIFF
--- a/lib/screens/4_receive/receive_screen.dart
+++ b/lib/screens/4_receive/receive_screen.dart
@@ -63,10 +63,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             ),
           ),
           body: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(AppDimensions.paddingMedium),
-              child: _showSuccess ? _buildSuccessView() : _buildReceiveForm(),
-            ),
+            child: _showSuccess ? _buildSuccessView() : _buildReceiveForm(),
           ),
         ),
       ),
@@ -75,97 +72,114 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
 
   Widget _buildReceiveForm() {
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // Instrucciones
-        Text(
-          'Pega el token Cashu:',
-          style: TextStyle(
-            fontFamily: 'Inter',
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-            color: AppColors.textSecondary,
+        // Contenido scrolleable
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Instrucciones
+                Text(
+                  'Pega el token Cashu:',
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: AppDimensions.paddingSmall),
+
+                // Campo de texto para el token
+                _buildTokenInput(),
+
+                const SizedBox(height: AppDimensions.paddingMedium),
+
+                // Botón pegar del portapapeles
+                _buildPasteButton(),
+
+                const SizedBox(height: AppDimensions.paddingLarge),
+
+                // Preview del token (si es válido)
+                if (_isValidToken && _tokenInfo != null) _buildTokenPreview(),
+
+                // Mensaje de error (si hay)
+                if (_errorMessage != null) _buildErrorMessage(),
+              ],
+            ),
           ),
         ),
-        const SizedBox(height: AppDimensions.paddingSmall),
 
-        // Campo de texto para el token
-        _buildTokenInput(),
-
-        const SizedBox(height: AppDimensions.paddingMedium),
-
-        // Botón pegar del portapapeles
-        _buildPasteButton(),
-
-        const SizedBox(height: AppDimensions.paddingLarge),
-
-        // Preview del token (si es válido)
-        if (_isValidToken && _tokenInfo != null) _buildTokenPreview(),
-
-        // Mensaje de error (si hay)
-        if (_errorMessage != null) _buildErrorMessage(),
-
-        const Spacer(),
-
-        // Botón reclamar
-        _buildClaimButton(),
+        // Botón reclamar (fijo abajo)
+        Padding(
+          padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+          child: _buildClaimButton(),
+        ),
       ],
     );
   }
 
   Widget _buildSuccessView() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        // Icono de éxito
-        Container(
-          width: 100,
-          height: 100,
-          decoration: BoxDecoration(
-            color: AppColors.success.withValues(alpha: 0.2),
-            shape: BoxShape.circle,
-          ),
-          child: const Icon(
-            LucideIcons.checkCircle2,
-            color: AppColors.success,
-            size: 50,
-          ),
-        ),
-        const SizedBox(height: AppDimensions.paddingLarge),
+    return Padding(
+      padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Spacer(),
 
-        // Monto recibido
-        Builder(
-          builder: (context) {
-            final unit = _receivedUnit ?? context.read<WalletProvider>().activeUnit;
-            return Text(
-              '+${UnitFormatter.formatBalance(_receivedAmount, unit)} ${UnitFormatter.getUnitLabel(unit)}',
-              style: const TextStyle(
-                fontFamily: 'Inter',
-                fontSize: 36,
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            );
-          },
-        ),
-        const SizedBox(height: AppDimensions.paddingSmall),
-
-        Text(
-          'Tokens recibidos',
-          style: TextStyle(
-            fontFamily: 'Inter',
-            fontSize: 18,
-            color: AppColors.textSecondary,
+          // Icono de éxito
+          Container(
+            width: 100,
+            height: 100,
+            decoration: BoxDecoration(
+              color: AppColors.success.withValues(alpha: 0.2),
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(
+              LucideIcons.checkCircle2,
+              color: AppColors.success,
+              size: 50,
+            ),
           ),
-        ),
-        const SizedBox(height: AppDimensions.paddingLarge * 2),
+          const SizedBox(height: AppDimensions.paddingLarge),
 
-        // Botón volver
-        PrimaryButton(
-          text: 'Volver al inicio',
-          onPressed: () => Navigator.pop(context),
-        ),
-      ],
+          // Monto recibido
+          Builder(
+            builder: (context) {
+              final unit = _receivedUnit ?? context.read<WalletProvider>().activeUnit;
+              return Text(
+                '+${UnitFormatter.formatBalance(_receivedAmount, unit)} ${UnitFormatter.getUnitLabel(unit)}',
+                style: const TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 36,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: AppDimensions.paddingSmall),
+
+          Text(
+            'Tokens recibidos',
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 18,
+              color: AppColors.textSecondary,
+            ),
+          ),
+
+          const Spacer(),
+
+          // Botón volver (fijo abajo)
+          PrimaryButton(
+            text: 'Volver al inicio',
+            onPressed: () => Navigator.pop(context),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/5_send/send_screen.dart
+++ b/lib/screens/5_send/send_screen.dart
@@ -91,30 +91,38 @@ class _SendScreenState extends State<SendScreen> {
           ],
         ),
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(AppDimensions.paddingMedium),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Monto a enviar
-                _buildAmountSection(),
+          child: Column(
+            children: [
+              // Contenido scrolleable
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Monto a enviar
+                      _buildAmountSection(),
 
-                const SizedBox(height: AppDimensions.paddingLarge),
+                      const SizedBox(height: AppDimensions.paddingLarge),
 
-                // Memo opcional
-                _buildMemoSection(),
+                      // Memo opcional
+                      _buildMemoSection(),
 
-                const SizedBox(height: AppDimensions.paddingMedium),
+                      const SizedBox(height: AppDimensions.paddingMedium),
 
-                // Mensaje de error (si hay)
-                if (_errorMessage != null) _buildErrorMessage(),
+                      // Mensaje de error (si hay)
+                      if (_errorMessage != null) _buildErrorMessage(),
+                    ],
+                  ),
+                ),
+              ),
 
-                const Spacer(),
-
-                // Botón crear token
-                _buildCreateButton(),
-              ],
-            ),
+              // Botón crear token (fijo abajo)
+              Padding(
+                padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                child: _buildCreateButton(),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/screens/5_send/share_token_screen.dart
+++ b/lib/screens/5_send/share_token_screen.dart
@@ -124,49 +124,57 @@ class _ShareTokenScreenState extends State<ShareTokenScreen> {
           ),
         ),
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(AppDimensions.paddingMedium),
-            child: Column(
-              children: [
-                const SizedBox(height: AppDimensions.paddingLarge),
+          child: Column(
+            children: [
+              // Contenido scrolleable
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                  child: Column(
+                    children: [
+                      const SizedBox(height: AppDimensions.paddingLarge),
 
-                // Icono de exito
-                _buildSuccessIcon(),
+                      // Icono de exito
+                      _buildSuccessIcon(),
 
-                const SizedBox(height: AppDimensions.paddingLarge),
+                      const SizedBox(height: AppDimensions.paddingLarge),
 
-                // Monto
-                _buildAmountDisplay(),
+                      // Monto
+                      _buildAmountDisplay(),
 
-                const SizedBox(height: AppDimensions.paddingLarge),
+                      const SizedBox(height: AppDimensions.paddingLarge),
 
-                // QR del token (dinámico si hay múltiples fragmentos)
-                _buildQRDisplay(),
+                      // QR del token (dinámico si hay múltiples fragmentos)
+                      _buildQRDisplay(),
 
-                const SizedBox(height: AppDimensions.paddingMedium),
+                      const SizedBox(height: AppDimensions.paddingMedium),
 
-                // Token truncado
-                _buildTokenTextDisplay(),
+                      // Token truncado
+                      _buildTokenTextDisplay(),
 
-                const SizedBox(height: AppDimensions.paddingMedium),
+                      const SizedBox(height: AppDimensions.paddingMedium),
 
-                // Botones copiar y compartir
-                _buildActionButtons(context),
+                      // Botones copiar y compartir
+                      _buildActionButtons(context),
 
-                const SizedBox(height: AppDimensions.paddingLarge),
+                      const SizedBox(height: AppDimensions.paddingLarge),
 
-                // Advertencia
-                _buildWarning(),
+                      // Advertencia
+                      _buildWarning(),
+                    ],
+                  ),
+                ),
+              ),
 
-                const Spacer(),
-
-                // Boton volver al inicio
-                PrimaryButton(
+              // Botón volver al inicio (fijo abajo)
+              Padding(
+                padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                child: PrimaryButton(
                   text: 'Volver al inicio',
                   onPressed: () => _goToHome(context),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/screens/6_mint/invoice_screen.dart
+++ b/lib/screens/6_mint/invoice_screen.dart
@@ -220,36 +220,48 @@ class _InvoiceScreenState extends State<InvoiceScreen> {
 
   Widget _buildInvoiceView() {
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // Título con monto
-        _buildHeader(),
+        // Contenido scrolleable
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Título con monto
+                _buildHeader(),
 
-        const SizedBox(height: AppDimensions.paddingLarge),
+                const SizedBox(height: AppDimensions.paddingLarge),
 
-        // QR del invoice
-        if (_invoice != null) _buildQRSection(),
+                // QR del invoice
+                if (_invoice != null) _buildQRSection(),
 
-        const SizedBox(height: AppDimensions.paddingLarge),
+                const SizedBox(height: AppDimensions.paddingLarge),
 
-        // Invoice truncado
-        if (_invoice != null) _buildInvoiceText(),
+                // Invoice truncado
+                if (_invoice != null) _buildInvoiceText(),
 
-        const SizedBox(height: AppDimensions.paddingMedium),
+                const SizedBox(height: AppDimensions.paddingMedium),
 
-        // Botón copiar
-        if (_invoice != null && _status == MintStatus.unpaid) _buildCopyButton(),
+                // Botón copiar
+                if (_invoice != null && _status == MintStatus.unpaid) _buildCopyButton(),
+              ],
+            ),
+          ),
+        ),
 
-        const Spacer(),
+        // Estado y descripción (fijos abajo)
+        Column(
+          children: [
+            // Estado del invoice
+            _buildStatus(),
 
-        // Estado del invoice
-        _buildStatus(),
+            const SizedBox(height: AppDimensions.paddingMedium),
 
-        const SizedBox(height: AppDimensions.paddingMedium),
-
-        // Descripción (si existe)
-        if (widget.description != null && widget.description!.isNotEmpty)
-          _buildDescription(),
+            // Descripción (si existe)
+            if (widget.description != null && widget.description!.isNotEmpty)
+              _buildDescription(),
+          ],
+        ),
       ],
     );
   }

--- a/lib/screens/6_mint/mint_screen.dart
+++ b/lib/screens/6_mint/mint_screen.dart
@@ -70,30 +70,38 @@ class _MintScreenState extends State<MintScreen> {
           ),
         ),
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(AppDimensions.paddingMedium),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Monto a depositar
-                _buildAmountSection(),
+          child: Column(
+            children: [
+              // Contenido scrolleable
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Monto a depositar
+                      _buildAmountSection(),
 
-                const SizedBox(height: AppDimensions.paddingLarge),
+                      const SizedBox(height: AppDimensions.paddingLarge),
 
-                // Descripción opcional
-                _buildDescriptionSection(),
+                      // Descripción opcional
+                      _buildDescriptionSection(),
 
-                const SizedBox(height: AppDimensions.paddingMedium),
+                      const SizedBox(height: AppDimensions.paddingMedium),
 
-                // Mensaje de error (si hay)
-                if (_errorMessage != null) _buildErrorMessage(),
+                      // Mensaje de error (si hay)
+                      if (_errorMessage != null) _buildErrorMessage(),
+                    ],
+                  ),
+                ),
+              ),
 
-                const Spacer(),
-
-                // Botón generar invoice
-                _buildGenerateButton(),
-              ],
-            ),
+              // Botón generar invoice (fijo abajo)
+              Padding(
+                padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                child: _buildGenerateButton(),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/screens/7_melt/melt_screen.dart
+++ b/lib/screens/7_melt/melt_screen.dart
@@ -82,54 +82,67 @@ class _MeltScreenState extends State<MeltScreen> {
           ),
         ),
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(AppDimensions.paddingMedium),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Instrucciones
-                Text(
-                  'Pega el invoice Lightning:',
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                    color: AppColors.textSecondary,
+          child: Column(
+            children: [
+              // Contenido scrolleable
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Instrucciones
+                      Text(
+                        'Pega el invoice Lightning:',
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(height: AppDimensions.paddingSmall),
+
+                      // Campo de texto para el invoice
+                      _buildInvoiceInput(),
+
+                      const SizedBox(height: AppDimensions.paddingMedium),
+
+                      // Botón pegar del portapapeles
+                      _buildPasteButton(),
+
+                      const SizedBox(height: AppDimensions.paddingLarge),
+
+                      // Loading quote
+                      if (_isLoadingQuote) _buildLoadingQuote(),
+
+                      // Preview del invoice (si es válido)
+                      if (_isValidInvoice && _quote != null && !_isLoadingQuote)
+                        _buildInvoicePreview(),
+
+                      // Mensaje de error (si hay)
+                      if (_errorMessage != null) _buildErrorMessage(),
+                    ],
                   ),
                 ),
-                const SizedBox(height: AppDimensions.paddingSmall),
+              ),
 
-                // Campo de texto para el invoice
-                _buildInvoiceInput(),
+              // Balance y botón (fijos abajo)
+              Padding(
+                padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+                child: Column(
+                  children: [
+                    // Balance disponible
+                    _buildBalanceInfo(),
 
-                const SizedBox(height: AppDimensions.paddingMedium),
+                    const SizedBox(height: AppDimensions.paddingMedium),
 
-                // Botón pegar del portapapeles
-                _buildPasteButton(),
-
-                const SizedBox(height: AppDimensions.paddingLarge),
-
-                // Loading quote
-                if (_isLoadingQuote) _buildLoadingQuote(),
-
-                // Preview del invoice (si es válido)
-                if (_isValidInvoice && _quote != null && !_isLoadingQuote)
-                  _buildInvoicePreview(),
-
-                // Mensaje de error (si hay)
-                if (_errorMessage != null) _buildErrorMessage(),
-
-                const Spacer(),
-
-                // Balance disponible
-                _buildBalanceInfo(),
-
-                const SizedBox(height: AppDimensions.paddingMedium),
-
-                // Botón pagar invoice
-                _buildPayButton(),
-              ],
-            ),
+                    // Botón pagar invoice
+                    _buildPayButton(),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
- Replace Spacer() with SingleChildScrollView in 6 screens                    
- Keep action buttons fixed at the bottom                                     
- Allow content scrolling when keyboard is open                               
- Prevent element overlapping on small screens                                
                                                                              
Fixed screens:                                                                
- ReceiveScreen                                                               
- SendScreen                                                                  
- ShareTokenScreen                                                            
- MintScreen                                                                  
- InvoiceScreen                                                               
- MeltScreen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrolling behavior on receive, send, share token, invoice, mint, and melt screens for better content accessibility
  * Fixed action buttons to remain accessible at the bottom while content scrolls above
  * Enhanced layout structure to better adapt to varying content sizes across different screens
  * Optimized vertical spacing and component positioning for improved visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->