### PR TITLE
fix: add SafeArea to screens and fix bottom sheet overlap

### DIFF
--- a/lib/screens/10_scanner/scan_screen.dart
+++ b/lib/screens/10_scanner/scan_screen.dart
@@ -53,10 +53,11 @@ class _ScanScreenState extends State<ScanScreen> {
         ),
         centerTitle: true,
       ),
-      body: Stack(
-        children: [
-          // Scanner
-          QrScannerWidget(
+      body: SafeArea(
+        child: Stack(
+          children: [
+            // Scanner
+            QrScannerWidget(
             onDetect: _onCodeDetected,
             showFlashControl: true,
             showCameraSwitch: false,
@@ -89,6 +90,7 @@ class _ScanScreenState extends State<ScanScreen> {
               ),
             ),
         ],
+        ),
       ),
     );
   }

--- a/lib/screens/3_home/home_screen.dart
+++ b/lib/screens/3_home/home_screen.dart
@@ -627,7 +627,8 @@ class _MethodSelectorModal extends StatelessWidget {
             ),
           ),
 
-          const SizedBox(height: AppDimensions.paddingSmall),
+          // Espacio para la barra de navegación del sistema
+          SizedBox(height: MediaQuery.of(context).padding.bottom + AppDimensions.paddingSmall),
         ],
       ),
     );

--- a/lib/screens/8_settings/mint_detail_screen.dart
+++ b/lib/screens/8_settings/mint_detail_screen.dart
@@ -51,9 +51,10 @@ class _MintDetailScreenState extends State<MintDetailScreen> {
             onPressed: () => Navigator.pop(context),
           ),
         ),
-        body: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
             child: Column(
               children: [
                 // Header: Logo + Nombre
@@ -93,6 +94,7 @@ class _MintDetailScreenState extends State<MintDetailScreen> {
                 const SizedBox(height: 40),
               ],
             ),
+          ),
           ),
         ),
       ),

--- a/lib/screens/9_history/history_screen.dart
+++ b/lib/screens/9_history/history_screen.dart
@@ -77,16 +77,18 @@ class _HistoryScreenState extends State<HistoryScreen> {
             ),
           ],
         ),
-        body: Column(
-          children: [
-            // Filtros
-            _buildFilters(),
+        body: SafeArea(
+          child: Column(
+            children: [
+              // Filtros
+              _buildFilters(),
 
-            // Lista de transacciones
-            Expanded(
-              child: _buildTransactionList(),
-            ),
-          ],
+              // Lista de transacciones
+              Expanded(
+                child: _buildTransactionList(),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
- Add SafeArea to scan_screen, mint_detail_screen and history_screen                                                                                  
- Fix home bottom sheet to respect system navigation bar    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced layout handling across multiple screens to properly respect device safe areas, notches, and system UI elements (status bars, navigation bars).
  * Updated bottom spacing on the home screen to dynamically adapt to device-specific safe area requirements.
  * Improved content positioning on scanner, settings, and history screens to avoid overlapping with system UI intrusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->