### PR TITLE
Fix: show full lightning address instead of username only

### DIFF
--- a/lib/screens/7_melt/amount_screen.dart
+++ b/lib/screens/7_melt/amount_screen.dart
@@ -240,7 +240,7 @@ class _AmountScreenState extends State<AmountScreen> {
                 ),
                 const SizedBox(height: 2),
                 Text(
-                  widget.params.description ?? widget.destination,
+                  'Payment to ${widget.destination}',
                   style: const TextStyle(
                     fontFamily: 'Inter',
                     fontSize: 14,


### PR DESCRIPTION
- Display complete lightning address (user@domain.com) instead of just the username                                                                   
- Improves clarity for users when sending payments  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment destination display text formatting for clearer presentation in the payment screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->