### PR TITLE
fix: improve Lightning deposit UX and global confetti

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'providers/wallet_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/price_provider.dart';
 import 'providers/p2pk_provider.dart';
+import 'widgets/effects/cashu_confetti.dart';
 import 'screens/1_splash/splash_screen.dart';
 
 void main() async {
@@ -82,6 +83,14 @@ class ElCajuApp extends StatelessWidget {
         Locale('sw'), // Kiswahili
       ],
       locale: Locale(settingsProvider.locale),
+
+      builder: (context, child) {
+        final walletProvider = context.read<WalletProvider>();
+        return CashuConfetti(
+          controller: walletProvider.confettiController,
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
 
       home: const SplashScreen(),
     );

--- a/lib/screens/3_home/home_screen.dart
+++ b/lib/screens/3_home/home_screen.dart
@@ -9,7 +9,6 @@ import '../../core/utils/incoming_data_parser.dart';
 import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/common/animated_action_button.dart';
-import '../../widgets/effects/cashu_confetti.dart';
 import '../../providers/wallet_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../4_receive/receive_screen.dart';
@@ -34,9 +33,6 @@ class _HomeScreenState extends State<HomeScreen> {
   // Estado local
   bool _isBalanceVisible = true;
 
-  // Controller para el efecto confeti
-  final CashuConfettiController _confettiController = CashuConfettiController();
-
   @override
   void initState() {
     super.initState();
@@ -46,11 +42,8 @@ class _HomeScreenState extends State<HomeScreen> {
     });
   }
 
-  @override
-  void dispose() {
-    _confettiController.dispose();
-    super.dispose();
-  }
+  /// Dispara confetti global desde WalletProvider
+  void _fireConfetti() => context.read<WalletProvider>().confettiController.fire();
 
   /// Verifica y reclama automáticamente tokens pendientes
   Future<void> _checkPendingTokens() async {
@@ -64,9 +57,7 @@ class _HomeScreenState extends State<HomeScreen> {
       final unit = (result['unit'] as String?) ?? walletProvider.activeUnit;
 
       if (claimed > 0 && mounted) {
-        // Disparar confetti
-        _confettiController.fire();
-
+        // Confetti se dispara globalmente desde WalletProvider.receiveToken
         // Mostrar snackbar
         final l10n = L10n.of(context)!;
         ScaffoldMessenger.of(context).showSnackBar(
@@ -84,9 +75,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return CashuConfetti(
-      controller: _confettiController,
-      child: GradientBackground(
+    return GradientBackground(
         child: Scaffold(
           backgroundColor: Colors.transparent,
           body: SafeArea(
@@ -122,7 +111,6 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
           ),
         ),
-      ),
     );
   }
 
@@ -161,7 +149,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
           // El Caju (derecha) - toca para confeti
           GestureDetector(
-            onTap: () => _confettiController.fire(),
+            onTap: () => _fireConfetti(),
             child: Image.asset(
               'assets/img/elcajucubano.png',
               width: 56,

--- a/lib/screens/4_receive/receive_screen.dart
+++ b/lib/screens/4_receive/receive_screen.dart
@@ -11,7 +11,6 @@ import '../../core/utils/nostr_utils.dart';
 import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/common/primary_button.dart';
-import '../../widgets/effects/cashu_confetti.dart';
 import '../../providers/wallet_provider.dart';
 import '../../providers/p2pk_provider.dart';
 import '../10_scanner/scan_screen.dart';
@@ -29,8 +28,6 @@ class ReceiveScreen extends StatefulWidget {
 
 class _ReceiveScreenState extends State<ReceiveScreen> {
   final TextEditingController _tokenController = TextEditingController();
-  final CashuConfettiController _confettiController = CashuConfettiController();
-
   // Estado del token
   bool _isValidToken = false;
   bool _isProcessing = false;
@@ -65,15 +62,12 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
   void dispose() {
     _tokenController.dispose();
     _manualKeyController.dispose();
-    _confettiController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return CashuConfetti(
-      controller: _confettiController,
-      child: GradientBackground(
+    return GradientBackground(
         child: Scaffold(
           backgroundColor: Colors.transparent,
           appBar: AppBar(
@@ -96,7 +90,6 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             child: _showSuccess ? _buildSuccessView() : _buildReceiveForm(),
           ),
         ),
-      ),
     );
   }
 
@@ -1027,8 +1020,7 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
           _isProcessing = false;
         });
 
-        // Disparar confetti
-        _confettiController.fire();
+        // Confetti se dispara globalmente desde WalletProvider.receiveToken
       }
     } catch (e) {
       if (!mounted) return;

--- a/lib/screens/9_history/history_screen.dart
+++ b/lib/screens/9_history/history_screen.dart
@@ -704,12 +704,30 @@ class _TransactionDetailScreenState extends State<_TransactionDetailScreen> {
     final meta = widget.walletProvider.getTransactionMeta(widget.transaction.id);
     _tokenOrInvoice = meta?.token ?? meta?.invoice;
 
+    // Si es Lightning incoming sin invoice, buscar en pending mint invoices
+    if (_tokenOrInvoice == null && _isLightning && _isIncoming) {
+      _loadPendingMintInvoice();
+    }
+
     // Mostrar QR para todo EXCEPTO Lightning saliente
     _shouldShowQR = !_isLightning || _isIncoming;
 
     // Inicializar QR dinámico si es token Cashu
     if (_tokenOrInvoice != null && !_isLightning && _shouldShowQR) {
       _encodeTokenToUR();
+    }
+  }
+
+  /// Busca el invoice en pending mint invoices si no hay metadata.
+  Future<void> _loadPendingMintInvoice() async {
+    final invoice = await widget.walletProvider.findPendingMintInvoice(
+      widget.transaction.mintUrl,
+      widget.transaction.unit,
+    );
+    if (invoice != null && mounted) {
+      setState(() {
+        _tokenOrInvoice = invoice;
+      });
     }
   }
 


### PR DESCRIPTION
- Allow back navigation from invoice screen without canceling payment    
- Save invoice to SharedPreferences when quote is created (before payment)                                                                 
- Detect Lightning transactions without metadata (heuristic: incoming without meta = Lightning)                                                
- Match pending invoices with new transactions in checkPendingTransactions
- Move confetti to app level (fires from any screen)
- Keep mint stream subscription in WalletProvider (independent of UI lifecycle)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified confetti celebration for receive and mint actions (now globally triggered).
  * Persistent pending Lightning mint invoices with automatic matching to incoming tokens.
  * History/detail view now falls back to pending invoice data to show QR/token when metadata is missing.

* **Bug Fixes**
  * Improved transaction type inference for Lightning payments lacking stored metadata.

* **Chores**
  * Removed local confetti wrappers and simplified related UI wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->