### PR TITLE
fix: normalize mnemonic whitespace before saving to secure storage

### DIFF
--- a/lib/screens/2_onboarding/restore_wallet_screen.dart
+++ b/lib/screens/2_onboarding/restore_wallet_screen.dart
@@ -63,12 +63,12 @@ class _RestoreWalletScreenState extends State<RestoreWalletScreen> {
       final settingsProvider = context.read<SettingsProvider>();
       final p2pkProvider = context.read<P2PKProvider>();
 
-      // Guardar mnemonic de forma segura
-      await settingsProvider.saveMnemonic(mnemonic);
-
-      // Inicializar wallet (esto valida el mnemonic internamente)
-      // Si el mnemonic es inválido, cdk_flutter lanzará una excepción
+      // Inicializar wallet primero (valida el mnemonic internamente).
+      // Si es inválido, cdk_flutter lanzará una excepción antes de persistir.
       await walletProvider.initialize(mnemonic);
+
+      // Solo guardar mnemonic si initialize() pasó sin error
+      await settingsProvider.saveMnemonic(mnemonic);
 
       // Inicializar P2PK (derivar clave principal del mnemonic)
       try {
@@ -100,9 +100,13 @@ class _RestoreWalletScreenState extends State<RestoreWalletScreen> {
         );
       }
     } catch (e) {
-      // Revertir el guardado del mnemonic si falló la inicialización
-      final settingsProvider = context.read<SettingsProvider>();
-      await settingsProvider.deleteWallet();
+      // Limpiar cualquier estado parcial si algo falló
+      try {
+        final settingsProvider = context.read<SettingsProvider>();
+        await settingsProvider.deleteWallet();
+      } catch (cleanupError) {
+        debugPrint('Error during restore cleanup: $cleanupError');
+      }
 
       final l10n = L10n.of(context)!;
       setState(() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery phrase handling: trims, lowercases, and collapses extra whitespace for more reliable wallet restoration.
  * Wallet persistence now occurs only after a successful restore; failed restores no longer leave partial state and perform safer cleanup, with cleanup issues logged for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->