### PR TITLE
fix: crash on Lightning incoming transaction detail without saved metadata

### DIFF
--- a/lib/screens/9_history/history_screen.dart
+++ b/lib/screens/9_history/history_screen.dart
@@ -691,7 +691,7 @@ class _TransactionDetailScreenState extends State<_TransactionDetailScreen> {
   // Datos de la transacción
   late final bool _isIncoming;
   late final bool _isLightning;
-  late final String? _tokenOrInvoice;
+  String? _tokenOrInvoice;
   late final bool _shouldShowQR;
 
   @override


### PR DESCRIPTION
Remove late final from _tokenOrInvoice to allow reassignment in _loadPendingMintInvoice(). The field is initialized in initState() but  may be updated later via setState(), which crashes with LateInitializationError when the variable is declared as late final.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for better flexibility in state management within the history screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->