### PR TITLE
ui: suppress invoice placeholder flash while loading pending mint invoice

### DIFF
--- a/lib/screens/9_history/history_screen.dart
+++ b/lib/screens/9_history/history_screen.dart
@@ -693,6 +693,7 @@ class _TransactionDetailScreenState extends State<_TransactionDetailScreen> {
   late final bool _isLightning;
   String? _tokenOrInvoice;
   late final bool _shouldShowQR;
+  bool _isLoadingPendingInvoice = false;
 
   @override
   void initState() {
@@ -720,13 +721,15 @@ class _TransactionDetailScreenState extends State<_TransactionDetailScreen> {
 
   /// Busca el invoice en pending mint invoices si no hay metadata.
   Future<void> _loadPendingMintInvoice() async {
+    setState(() => _isLoadingPendingInvoice = true);
     final invoice = await widget.walletProvider.findPendingMintInvoice(
       widget.transaction.mintUrl,
       widget.transaction.unit,
     );
-    if (invoice != null && mounted) {
+    if (mounted) {
       setState(() {
-        _tokenOrInvoice = invoice;
+        _isLoadingPendingInvoice = false;
+        if (invoice != null) _tokenOrInvoice = invoice;
       });
     }
   }
@@ -869,8 +872,8 @@ class _TransactionDetailScreenState extends State<_TransactionDetailScreen> {
                   const SizedBox(height: 32),
                 ],
 
-                // Mensaje si no hay token/invoice
-                if (_tokenOrInvoice == null) ...[
+                // Mensaje si no hay token/invoice (ocultar mientras carga)
+                if (_tokenOrInvoice == null && !_isLoadingPendingInvoice) ...[
                   Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(


### PR DESCRIPTION
Add _isLoadingPendingInvoice flag to hide the "invoice not available" placeholder while the async lookup is in progress. The placeholder now only shows after the search completes with no result.      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state management for pending mint invoices, ensuring proper feedback is displayed during data retrieval operations in the transaction detail view.
  * Fixed UI display logic to prevent confusing "no token or invoice found" messages from appearing while pending invoices are being loaded, providing clearer indication of the app's current state to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->