### PR TITLE
fix: add try/catch to _loadPendingMintInvoice to prevent stuck loading state

### DIFF
--- a/lib/screens/9_history/history_screen.dart
+++ b/lib/screens/9_history/history_screen.dart
@@ -728,8 +728,8 @@ class _TransactionDetailScreenState extends State<_TransactionDetailScreen> {
         widget.transaction.mintUrl,
         widget.transaction.unit,
       );
-    } catch (_) {
-      // findPendingMintInvoice falló; invoice queda null
+    } catch (e, st) {
+      debugPrint('findPendingMintInvoice failed: $e\n$st');
     }
     if (mounted) {
       setState(() {


### PR DESCRIPTION
Wrap findPendingMintInvoice in try/catch so  _isLoadingPendingInvoice resets to false on error. Previously, a network failure or exception left the loading flag stuck, hiding both the QR and the placeholder indefinitely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice loading so failures no longer crash the UI: loading indicators now complete properly and pending invoices are only applied when successfully retrieved, preventing partial or invalid state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->