### PR TITLE
fix: release reserved proofs when confirmSend fails (#58)

### DIFF
--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1038,7 +1038,11 @@ class WalletProvider extends ChangeNotifier {
       debugPrint('[SEND] Send completed');
       return token;
     } catch (e) {
-      await cancelSend(prepared);
+      try {
+        await cancelSend(prepared);
+      } catch (cancelErr) {
+        debugPrint('[SEND] cancelSend failed: $cancelErr');
+      }
       rethrow;
     }
   }
@@ -1055,7 +1059,11 @@ class WalletProvider extends ChangeNotifier {
       debugPrint('[P2PK] Send completed');
       return token;
     } catch (e) {
-      await cancelSend(prepared);
+      try {
+        await cancelSend(prepared);
+      } catch (cancelErr) {
+        debugPrint('[P2PK] cancelSend failed: $cancelErr');
+      }
       rethrow;
     }
   }


### PR DESCRIPTION
Wrap confirmSend in try/catch and call cancelSend(prepared) on failure in both sendTokens() and sendTokensP2pk(). Previously, if confirmSend threw, reserved proofs stayed locked until checkPendingTransactions() ran on next app restart. Also cleaned up verbose debug logging in sendTokens().



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token send operations now use a safer two-step flow (prepare then confirm) with automatic cancellation if confirmation fails, preventing reserved resources from being left in limbo.
  * Improved logging around success, failure, and cleanup paths for clearer diagnostics and more reliable recovery across transfer methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->