### PR TITLE
feat: add QR scan button for P2PK pubkey input (#59)

### DIFF
--- a/lib/screens/5_send/send_screen.dart
+++ b/lib/screens/5_send/send_screen.dart
@@ -362,6 +362,7 @@ class _SendScreenState extends State<SendScreen> {
                         IconButton(
                           icon: const Icon(LucideIcons.scanLine, size: 20),
                           color: AppColors.textSecondary,
+                          tooltip: l10n.scanQrCode,
                           onPressed: _scanPubkey,
                         ),
                       ],
@@ -432,9 +433,25 @@ class _SendScreenState extends State<SendScreen> {
               final trimmed = data.trim();
               if (NostrUtils.isValidP2PKPubkey(trimmed)) {
                 Navigator.pop(context, trimmed);
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(L10n.of(context)!.p2pkInvalidPubkey),
+                    duration: const Duration(seconds: 2),
+                  ),
+                );
               }
             },
-            onError: (error) => debugPrint('[P2PK Scan] $error'),
+            onError: (error) {
+              debugPrint('[P2PK Scan] $error');
+              Navigator.pop(context);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(L10n.of(context)!.cameraPermissionDenied),
+                  backgroundColor: AppColors.error,
+                ),
+              );
+            },
           ),
         ),
       ),


### PR DESCRIPTION
Add a scan button next to the paste button in the P2PK pubkey field.
Opens a fullscreen QR scanner using the existing QrScannerWidget.
Accepts npub and hex (64/66 chars) formats, validated with NostrUtils.isValidP2PKPubkey() before returning.

Closes #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR code scanning support for P2PK pubkey entry on the send screen. Users can now use the new scan button positioned alongside the paste option to capture and validate QR codes directly. Successfully scanned QR codes are automatically validated and populate the pubkey input field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->