### PR TITLE
fix: add startup recovery for lost proofs and pending operations

### DIFF
--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1393,12 +1393,44 @@ class WalletProvider extends ChangeNotifier {
   /// Llamar en background al iniciar la app.
   /// También vincula transacciones incoming sin metadata con invoices pendientes.
   Future<void> checkPendingTransactions() async {
-    for (final wallet in _wallets.values) {
-      try {
-        await wallet.checkPendingTransactions();
-      } catch (e) {
-        // Silencioso - puede fallar offline
-        debugPrint('Check pending failed: $e');
+    // Iterar todos los mints y todas sus unidades, no solo los wallets
+    // ya instanciados. initialize() solo precarga units.first por mint,
+    // así que quotes/sagas/melts en otras unidades se perderían.
+    for (final entry in _mintUnits.entries) {
+      for (final unit in entry.value) {
+        try {
+          final wallet = await getWallet(entry.key, unit);
+
+          try {
+            // Reclamar quotes pagados pero no emitidos (Lightning → proofs)
+            await wallet.checkAllMintQuotes();
+          } catch (e) {
+            debugPrint('Check mint quotes failed: $e');
+          }
+
+          try {
+            // Recuperar sagas incompletas (swaps/mints/melts interrumpidos)
+            await wallet.recoverIncompleteSagas();
+          } catch (e) {
+            debugPrint('Recover incomplete sagas failed: $e');
+          }
+
+          try {
+            // Finalizar retiros Lightning que quedaron a medias
+            await wallet.finalizePendingMelts();
+          } catch (e) {
+            debugPrint('Finalize pending melts failed: $e');
+          }
+
+          try {
+            await wallet.checkPendingTransactions();
+          } catch (e) {
+            // Silencioso - puede fallar offline
+            debugPrint('Check pending failed: $e');
+          }
+        } catch (e) {
+          debugPrint('Error getting wallet ${entry.key}:$unit: $e');
+        }
       }
     }
 


### PR DESCRIPTION
Add three recovery methods to the app startup flow that run before the existing checkPendingTransactions():

- checkAllMintQuotes(): reclaims proofs from Lightning deposits that were paid but never issued (quote PAID, proofs not claimed)
- recoverIncompleteSagas(): resumes interrupted mint/swap/send/melt operations that left proofs in limbo
- finalizePendingMelts(): completes Lightning withdrawals that were interrupted mid-flow

Each method runs in its own try/catch so a failure in one does not block the others. All three methods already exist in cdk-flutter but were never called by ElCaju.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust processing of pending transactions across all configured mints/units: the app now loads wallets on demand, runs staged recovery attempts per wallet with isolated error handling so failures don’t stop other recovery steps, and completes a final pending-invoice matching pass—reducing stuck or incomplete transactions and improving wallet stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->