### PR TITLE
feat: add swap screen UI (sats -> USD) with price chart

### DIFF
--- a/lib/core/services/price_service.dart
+++ b/lib/core/services/price_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 import 'package:http/http.dart' as http;
 
 /// Servicio para obtener precios de Bitcoin usando Yadio API
@@ -86,4 +87,56 @@ class PriceService {
     // Retornar en centavos
     return BigInt.from((fiatAmount * 100).round());
   }
+
+  // --- Blink API (precios históricos) ---
+
+  static const _blinkUrl = 'https://api.blink.sv/graphql';
+
+  /// Obtiene precios históricos de BTC desde Blink API.
+  /// range: ONE_DAY, ONE_WEEK, ONE_MONTH, ONE_YEAR, FIVE_YEARS
+  static Future<List<PricePoint>> getHistoricalPrices({
+    String range = 'ONE_DAY',
+  }) async {
+    try {
+      final response = await http.post(
+        Uri.parse(_blinkUrl),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'query':
+              'query { btcPriceList(range: $range) { price { base offset } timestamp } }',
+        }),
+      ).timeout(const Duration(seconds: 15));
+
+      if (response.statusCode != 200) {
+        throw Exception('Error HTTP: ${response.statusCode}');
+      }
+
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final data = json['data'] as Map<String, dynamic>?;
+      if (data == null) throw Exception('No data in response');
+
+      final list = data['btcPriceList'] as List? ?? [];
+
+      return list.map((point) {
+        final price = point['price'] as Map<String, dynamic>;
+        final base = (price['base'] as num).toDouble();
+        final offset = (price['offset'] as num).toInt();
+        // base / 10^offset = USD cents → /100 = USD
+        final priceUsd = base / pow(10, offset) / 100;
+        final timestamp = (point['timestamp'] as num).toInt();
+
+        return PricePoint(timestamp: timestamp, priceUsd: priceUsd);
+      }).toList();
+    } catch (e) {
+      throw Exception('Error obteniendo precios históricos: $e');
+    }
+  }
+}
+
+/// Punto de precio histórico de BTC
+class PricePoint {
+  final int timestamp;
+  final double priceUsd;
+
+  PricePoint({required this.timestamp, required this.priceUsd});
 }

--- a/lib/core/services/price_service.dart
+++ b/lib/core/services/price_service.dart
@@ -115,7 +115,10 @@ class PriceService {
       final data = json['data'] as Map<String, dynamic>?;
       if (data == null) throw Exception('No data in response');
 
-      final list = data['btcPriceList'] as List? ?? [];
+      final list = data['btcPriceList'] as List?;
+      if (list == null || list.isEmpty) {
+        throw Exception('No historical prices in response');
+      }
 
       return list.map((point) {
         final price = point['price'] as Map<String, dynamic>;

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "Zahlung erhalten",
   "requestDescriptionHint": "Beschreibung (optional)",
   "universal": "Universal",
-  "copiedToClipboard": "In die Zwischenablage kopiert"
+  "copiedToClipboard": "In die Zwischenablage kopiert",
+
+  "swap": "Tauschen",
+  "swapDescription": "Zwischen Sats und USD wechseln",
+  "swapFrom": "Von",
+  "swapTo": "Nach",
+  "swapAction": "Tauschen",
+  "swapEstimatedFee": "Geschätzte Gebühr",
+  "swapUseAll": "Alles verwenden"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -567,5 +567,11 @@
   "swapTo": "Nach",
   "swapAction": "Tauschen",
   "swapEstimatedFee": "Geschätzte Gebühr",
-  "swapUseAll": "Alles verwenden"
+  "swapUseAll": "Alles verwenden",
+  "swapMinimum": "Minimum: {amount}",
+  "swapProcessing": "Swap wird verarbeitet...",
+  "swapSuccess": "Swap abgeschlossen",
+  "swapErrorInsufficient": "Unzureichendes Guthaben",
+  "swapErrorExpired": "Angebot abgelaufen",
+  "swapErrorGeneric": "Swap-Fehler: {error}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -452,5 +452,13 @@
   "requestPaymentReceived": "Payment received",
   "requestDescriptionHint": "Description (optional)",
   "universal": "Universal",
-  "copiedToClipboard": "Copied to clipboard"
+  "copiedToClipboard": "Copied to clipboard",
+
+  "swap": "Swap",
+  "swapDescription": "Convert between sats and USD",
+  "swapFrom": "From",
+  "swapTo": "To",
+  "swapAction": "Swap",
+  "swapEstimatedFee": "Estimated fee",
+  "swapUseAll": "Use all"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -460,5 +460,11 @@
   "swapTo": "To",
   "swapAction": "Swap",
   "swapEstimatedFee": "Estimated fee",
-  "swapUseAll": "Use all"
+  "swapUseAll": "Use all",
+  "swapMinimum": "Minimum: {amount}",
+  "swapProcessing": "Processing swap...",
+  "swapSuccess": "Swap completed",
+  "swapErrorInsufficient": "Insufficient balance",
+  "swapErrorExpired": "Quote has expired",
+  "swapErrorGeneric": "Swap error: {error}"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -572,5 +572,13 @@
   "requestPaymentReceived": "Pago recibido",
   "requestDescriptionHint": "Descripción (opcional)",
   "universal": "Universal",
-  "copiedToClipboard": "Copiado al portapapeles"
+  "copiedToClipboard": "Copiado al portapapeles",
+
+  "swap": "Cambiar",
+  "swapDescription": "Convertir entre sats y USD",
+  "swapFrom": "De",
+  "swapTo": "A",
+  "swapAction": "Cambiar",
+  "swapEstimatedFee": "Fee estimado",
+  "swapUseAll": "Usar todo"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -580,5 +580,21 @@
   "swapTo": "A",
   "swapAction": "Cambiar",
   "swapEstimatedFee": "Fee estimado",
-  "swapUseAll": "Usar todo"
+  "swapUseAll": "Usar todo",
+  "swapMinimum": "Mínimo: {amount}",
+  "@swapMinimum": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "swapProcessing": "Procesando swap...",
+  "swapSuccess": "Swap completado",
+  "swapErrorInsufficient": "Saldo insuficiente",
+  "swapErrorExpired": "La cotización ha expirado",
+  "swapErrorGeneric": "Error en el swap: {error}",
+  "@swapErrorGeneric": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -567,5 +567,11 @@
   "swapTo": "Vers",
   "swapAction": "Échanger",
   "swapEstimatedFee": "Frais estimés",
-  "swapUseAll": "Tout utiliser"
+  "swapUseAll": "Tout utiliser",
+  "swapMinimum": "Minimum : {amount}",
+  "swapProcessing": "Swap en cours...",
+  "swapSuccess": "Swap terminé",
+  "swapErrorInsufficient": "Solde insuffisant",
+  "swapErrorExpired": "Le devis a expiré",
+  "swapErrorGeneric": "Erreur de swap : {error}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "Paiement reçu",
   "requestDescriptionHint": "Description (facultatif)",
   "universal": "Universel",
-  "copiedToClipboard": "Copié dans le presse-papiers"
+  "copiedToClipboard": "Copié dans le presse-papiers",
+
+  "swap": "Échanger",
+  "swapDescription": "Convertir entre sats et USD",
+  "swapFrom": "De",
+  "swapTo": "Vers",
+  "swapAction": "Échanger",
+  "swapEstimatedFee": "Frais estimés",
+  "swapUseAll": "Tout utiliser"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "Pagamento ricevuto",
   "requestDescriptionHint": "Descrizione (opzionale)",
   "universal": "Universale",
-  "copiedToClipboard": "Copiato negli appunti"
+  "copiedToClipboard": "Copiato negli appunti",
+
+  "swap": "Scambia",
+  "swapDescription": "Converti tra sats e USD",
+  "swapFrom": "Da",
+  "swapTo": "A",
+  "swapAction": "Scambia",
+  "swapEstimatedFee": "Commissione stimata",
+  "swapUseAll": "Usa tutto"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -567,5 +567,11 @@
   "swapTo": "A",
   "swapAction": "Scambia",
   "swapEstimatedFee": "Commissione stimata",
-  "swapUseAll": "Usa tutto"
+  "swapUseAll": "Usa tutto",
+  "swapMinimum": "Minimo: {amount}",
+  "swapProcessing": "Swap in corso...",
+  "swapSuccess": "Swap completato",
+  "swapErrorInsufficient": "Saldo insufficiente",
+  "swapErrorExpired": "Il preventivo è scaduto",
+  "swapErrorGeneric": "Errore swap: {error}"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "支払いを受け取りました",
   "requestDescriptionHint": "説明（任意）",
   "universal": "ユニバーサル",
-  "copiedToClipboard": "クリップボードにコピーしました"
+  "copiedToClipboard": "クリップボードにコピーしました",
+
+  "swap": "交換",
+  "swapDescription": "SatsとUSDを変換",
+  "swapFrom": "送信元",
+  "swapTo": "送信先",
+  "swapAction": "交換",
+  "swapEstimatedFee": "推定手数料",
+  "swapUseAll": "全額使用"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -567,5 +567,11 @@
   "swapTo": "送信先",
   "swapAction": "交換",
   "swapEstimatedFee": "推定手数料",
-  "swapUseAll": "全額使用"
+  "swapUseAll": "全額使用",
+  "swapMinimum": "最小: {amount}",
+  "swapProcessing": "スワップ処理中...",
+  "swapSuccess": "スワップ完了",
+  "swapErrorInsufficient": "残高不足",
+  "swapErrorExpired": "見積もりの有効期限切れ",
+  "swapErrorGeneric": "スワップエラー: {error}"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "결제가 수신되었습니다",
   "requestDescriptionHint": "설명 (선택사항)",
   "universal": "유니버설",
-  "copiedToClipboard": "클립보드에 복사되었습니다"
+  "copiedToClipboard": "클립보드에 복사되었습니다",
+
+  "swap": "교환",
+  "swapDescription": "Sats와 USD 간 변환",
+  "swapFrom": "보내기",
+  "swapTo": "받기",
+  "swapAction": "교환",
+  "swapEstimatedFee": "예상 수수료",
+  "swapUseAll": "전액 사용"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -563,9 +563,15 @@
 
   "swap": "교환",
   "swapDescription": "Sats와 USD 간 변환",
-  "swapFrom": "보내기",
-  "swapTo": "받기",
+  "swapFrom": "에서",
+  "swapTo": "으로",
   "swapAction": "교환",
   "swapEstimatedFee": "예상 수수료",
-  "swapUseAll": "전액 사용"
+  "swapUseAll": "전액 사용",
+  "swapMinimum": "최소: {amount}",
+  "swapProcessing": "교환 처리 중...",
+  "swapSuccess": "교환 완료",
+  "swapErrorInsufficient": "잔액 부족",
+  "swapErrorExpired": "견적이 만료되었습니다",
+  "swapErrorGeneric": "교환 오류: {error}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2394,6 +2394,42 @@ abstract class L10n {
   /// In es, this message translates to:
   /// **'Usar todo'**
   String get swapUseAll;
+
+  /// No description provided for @swapMinimum.
+  ///
+  /// In es, this message translates to:
+  /// **'Mínimo: {amount}'**
+  String swapMinimum(String amount);
+
+  /// No description provided for @swapProcessing.
+  ///
+  /// In es, this message translates to:
+  /// **'Procesando swap...'**
+  String get swapProcessing;
+
+  /// No description provided for @swapSuccess.
+  ///
+  /// In es, this message translates to:
+  /// **'Swap completado'**
+  String get swapSuccess;
+
+  /// No description provided for @swapErrorInsufficient.
+  ///
+  /// In es, this message translates to:
+  /// **'Saldo insuficiente'**
+  String get swapErrorInsufficient;
+
+  /// No description provided for @swapErrorExpired.
+  ///
+  /// In es, this message translates to:
+  /// **'La cotización ha expirado'**
+  String get swapErrorExpired;
+
+  /// No description provided for @swapErrorGeneric.
+  ///
+  /// In es, this message translates to:
+  /// **'Error en el swap: {error}'**
+  String swapErrorGeneric(String error);
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2352,6 +2352,48 @@ abstract class L10n {
   /// In es, this message translates to:
   /// **'Copiado al portapapeles'**
   String get copiedToClipboard;
+
+  /// No description provided for @swap.
+  ///
+  /// In es, this message translates to:
+  /// **'Cambiar'**
+  String get swap;
+
+  /// No description provided for @swapDescription.
+  ///
+  /// In es, this message translates to:
+  /// **'Convertir entre sats y USD'**
+  String get swapDescription;
+
+  /// No description provided for @swapFrom.
+  ///
+  /// In es, this message translates to:
+  /// **'De'**
+  String get swapFrom;
+
+  /// No description provided for @swapTo.
+  ///
+  /// In es, this message translates to:
+  /// **'A'**
+  String get swapTo;
+
+  /// No description provided for @swapAction.
+  ///
+  /// In es, this message translates to:
+  /// **'Cambiar'**
+  String get swapAction;
+
+  /// No description provided for @swapEstimatedFee.
+  ///
+  /// In es, this message translates to:
+  /// **'Fee estimado'**
+  String get swapEstimatedFee;
+
+  /// No description provided for @swapUseAll.
+  ///
+  /// In es, this message translates to:
+  /// **'Usar todo'**
+  String get swapUseAll;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1241,4 +1241,25 @@ class L10nDe extends L10n {
 
   @override
   String get copiedToClipboard => 'In die Zwischenablage kopiert';
+
+  @override
+  String get swap => 'Tauschen';
+
+  @override
+  String get swapDescription => 'Zwischen Sats und USD wechseln';
+
+  @override
+  String get swapFrom => 'Von';
+
+  @override
+  String get swapTo => 'Nach';
+
+  @override
+  String get swapAction => 'Tauschen';
+
+  @override
+  String get swapEstimatedFee => 'Geschätzte Gebühr';
+
+  @override
+  String get swapUseAll => 'Alles verwenden';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1262,4 +1262,26 @@ class L10nDe extends L10n {
 
   @override
   String get swapUseAll => 'Alles verwenden';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Minimum: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Swap wird verarbeitet...';
+
+  @override
+  String get swapSuccess => 'Swap abgeschlossen';
+
+  @override
+  String get swapErrorInsufficient => 'Unzureichendes Guthaben';
+
+  @override
+  String get swapErrorExpired => 'Angebot abgelaufen';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Swap-Fehler: $error';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1243,4 +1243,26 @@ class L10nEn extends L10n {
 
   @override
   String get swapUseAll => 'Use all';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Minimum: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Processing swap...';
+
+  @override
+  String get swapSuccess => 'Swap completed';
+
+  @override
+  String get swapErrorInsufficient => 'Insufficient balance';
+
+  @override
+  String get swapErrorExpired => 'Quote has expired';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Swap error: $error';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1222,4 +1222,25 @@ class L10nEn extends L10n {
 
   @override
   String get copiedToClipboard => 'Copied to clipboard';
+
+  @override
+  String get swap => 'Swap';
+
+  @override
+  String get swapDescription => 'Convert between sats and USD';
+
+  @override
+  String get swapFrom => 'From';
+
+  @override
+  String get swapTo => 'To';
+
+  @override
+  String get swapAction => 'Swap';
+
+  @override
+  String get swapEstimatedFee => 'Estimated fee';
+
+  @override
+  String get swapUseAll => 'Use all';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1251,4 +1251,26 @@ class L10nEs extends L10n {
 
   @override
   String get swapUseAll => 'Usar todo';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Mínimo: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Procesando swap...';
+
+  @override
+  String get swapSuccess => 'Swap completado';
+
+  @override
+  String get swapErrorInsufficient => 'Saldo insuficiente';
+
+  @override
+  String get swapErrorExpired => 'La cotización ha expirado';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Error en el swap: $error';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1230,4 +1230,25 @@ class L10nEs extends L10n {
 
   @override
   String get copiedToClipboard => 'Copiado al portapapeles';
+
+  @override
+  String get swap => 'Cambiar';
+
+  @override
+  String get swapDescription => 'Convertir entre sats y USD';
+
+  @override
+  String get swapFrom => 'De';
+
+  @override
+  String get swapTo => 'A';
+
+  @override
+  String get swapAction => 'Cambiar';
+
+  @override
+  String get swapEstimatedFee => 'Fee estimado';
+
+  @override
+  String get swapUseAll => 'Usar todo';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1267,4 +1267,26 @@ class L10nFr extends L10n {
 
   @override
   String get swapUseAll => 'Tout utiliser';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Minimum : $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Swap en cours...';
+
+  @override
+  String get swapSuccess => 'Swap terminé';
+
+  @override
+  String get swapErrorInsufficient => 'Solde insuffisant';
+
+  @override
+  String get swapErrorExpired => 'Le devis a expiré';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Erreur de swap : $error';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1246,4 +1246,25 @@ class L10nFr extends L10n {
 
   @override
   String get copiedToClipboard => 'Copié dans le presse-papiers';
+
+  @override
+  String get swap => 'Échanger';
+
+  @override
+  String get swapDescription => 'Convertir entre sats et USD';
+
+  @override
+  String get swapFrom => 'De';
+
+  @override
+  String get swapTo => 'Vers';
+
+  @override
+  String get swapAction => 'Échanger';
+
+  @override
+  String get swapEstimatedFee => 'Frais estimés';
+
+  @override
+  String get swapUseAll => 'Tout utiliser';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1255,4 +1255,26 @@ class L10nIt extends L10n {
 
   @override
   String get swapUseAll => 'Usa tutto';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Minimo: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Swap in corso...';
+
+  @override
+  String get swapSuccess => 'Swap completato';
+
+  @override
+  String get swapErrorInsufficient => 'Saldo insufficiente';
+
+  @override
+  String get swapErrorExpired => 'Il preventivo è scaduto';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Errore swap: $error';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1234,4 +1234,25 @@ class L10nIt extends L10n {
 
   @override
   String get copiedToClipboard => 'Copiato negli appunti';
+
+  @override
+  String get swap => 'Scambia';
+
+  @override
+  String get swapDescription => 'Converti tra sats e USD';
+
+  @override
+  String get swapFrom => 'Da';
+
+  @override
+  String get swapTo => 'A';
+
+  @override
+  String get swapAction => 'Scambia';
+
+  @override
+  String get swapEstimatedFee => 'Commissione stimata';
+
+  @override
+  String get swapUseAll => 'Usa tutto';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1228,4 +1228,26 @@ class L10nJa extends L10n {
 
   @override
   String get swapUseAll => '全額使用';
+
+  @override
+  String swapMinimum(String amount) {
+    return '最小: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'スワップ処理中...';
+
+  @override
+  String get swapSuccess => 'スワップ完了';
+
+  @override
+  String get swapErrorInsufficient => '残高不足';
+
+  @override
+  String get swapErrorExpired => '見積もりの有効期限切れ';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'スワップエラー: $error';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1207,4 +1207,25 @@ class L10nJa extends L10n {
 
   @override
   String get copiedToClipboard => 'クリップボードにコピーしました';
+
+  @override
+  String get swap => '交換';
+
+  @override
+  String get swapDescription => 'SatsとUSDを変換';
+
+  @override
+  String get swapFrom => '送信元';
+
+  @override
+  String get swapTo => '送信先';
+
+  @override
+  String get swapAction => '交換';
+
+  @override
+  String get swapEstimatedFee => '推定手数料';
+
+  @override
+  String get swapUseAll => '全額使用';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1217,10 +1217,10 @@ class L10nKo extends L10n {
   String get swapDescription => 'Sats와 USD 간 변환';
 
   @override
-  String get swapFrom => '보내기';
+  String get swapFrom => '에서';
 
   @override
-  String get swapTo => '받기';
+  String get swapTo => '으로';
 
   @override
   String get swapAction => '교환';
@@ -1230,4 +1230,26 @@ class L10nKo extends L10n {
 
   @override
   String get swapUseAll => '전액 사용';
+
+  @override
+  String swapMinimum(String amount) {
+    return '최소: $amount';
+  }
+
+  @override
+  String get swapProcessing => '교환 처리 중...';
+
+  @override
+  String get swapSuccess => '교환 완료';
+
+  @override
+  String get swapErrorInsufficient => '잔액 부족';
+
+  @override
+  String get swapErrorExpired => '견적이 만료되었습니다';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return '교환 오류: $error';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1209,4 +1209,25 @@ class L10nKo extends L10n {
 
   @override
   String get copiedToClipboard => '클립보드에 복사되었습니다';
+
+  @override
+  String get swap => '교환';
+
+  @override
+  String get swapDescription => 'Sats와 USD 간 변환';
+
+  @override
+  String get swapFrom => '보내기';
+
+  @override
+  String get swapTo => '받기';
+
+  @override
+  String get swapAction => '교환';
+
+  @override
+  String get swapEstimatedFee => '예상 수수료';
+
+  @override
+  String get swapUseAll => '전액 사용';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1255,4 +1255,26 @@ class L10nPt extends L10n {
 
   @override
   String get swapUseAll => 'Usar tudo';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Mínimo: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Processando swap...';
+
+  @override
+  String get swapSuccess => 'Swap concluído';
+
+  @override
+  String get swapErrorInsufficient => 'Saldo insuficiente';
+
+  @override
+  String get swapErrorExpired => 'A cotação expirou';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Erro no swap: $error';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1234,4 +1234,25 @@ class L10nPt extends L10n {
 
   @override
   String get copiedToClipboard => 'Copiado para a área de transferência';
+
+  @override
+  String get swap => 'Trocar';
+
+  @override
+  String get swapDescription => 'Converter entre sats e USD';
+
+  @override
+  String get swapFrom => 'De';
+
+  @override
+  String get swapTo => 'Para';
+
+  @override
+  String get swapAction => 'Trocar';
+
+  @override
+  String get swapEstimatedFee => 'Taxa estimada';
+
+  @override
+  String get swapUseAll => 'Usar tudo';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1230,4 +1230,25 @@ class L10nRu extends L10n {
 
   @override
   String get copiedToClipboard => 'Скопировано в буфер обмена';
+
+  @override
+  String get swap => 'Обменять';
+
+  @override
+  String get swapDescription => 'Конвертировать между sats и USD';
+
+  @override
+  String get swapFrom => 'Из';
+
+  @override
+  String get swapTo => 'В';
+
+  @override
+  String get swapAction => 'Обменять';
+
+  @override
+  String get swapEstimatedFee => 'Ориентировочная комиссия';
+
+  @override
+  String get swapUseAll => 'Использовать всё';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1251,4 +1251,26 @@ class L10nRu extends L10n {
 
   @override
   String get swapUseAll => 'Использовать всё';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Минимум: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Обработка обмена...';
+
+  @override
+  String get swapSuccess => 'Обмен завершён';
+
+  @override
+  String get swapErrorInsufficient => 'Недостаточный баланс';
+
+  @override
+  String get swapErrorExpired => 'Котировка истекла';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Ошибка обмена: $error';
+  }
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1231,4 +1231,25 @@ class L10nSw extends L10n {
 
   @override
   String get copiedToClipboard => 'Imenakiliwa kwenye ubao wa kunakili';
+
+  @override
+  String get swap => 'Badilisha';
+
+  @override
+  String get swapDescription => 'Badilisha kati ya sats na USD';
+
+  @override
+  String get swapFrom => 'Kutoka';
+
+  @override
+  String get swapTo => 'Kwenda';
+
+  @override
+  String get swapAction => 'Badilisha';
+
+  @override
+  String get swapEstimatedFee => 'Ada inayokadiriwa';
+
+  @override
+  String get swapUseAll => 'Tumia yote';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1252,4 +1252,26 @@ class L10nSw extends L10n {
 
   @override
   String get swapUseAll => 'Tumia yote';
+
+  @override
+  String swapMinimum(String amount) {
+    return 'Kiwango cha chini: $amount';
+  }
+
+  @override
+  String get swapProcessing => 'Inashughulikia ubadilishaji...';
+
+  @override
+  String get swapSuccess => 'Ubadilishaji umekamilika';
+
+  @override
+  String get swapErrorInsufficient => 'Salio haitoshi';
+
+  @override
+  String get swapErrorExpired => 'Bei imeisha muda';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return 'Kosa la ubadilishaji: $error';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1202,4 +1202,25 @@ class L10nZh extends L10n {
 
   @override
   String get copiedToClipboard => '已复制到剪贴板';
+
+  @override
+  String get swap => '兑换';
+
+  @override
+  String get swapDescription => '在 Sats 和 USD 之间转换';
+
+  @override
+  String get swapFrom => '从';
+
+  @override
+  String get swapTo => '到';
+
+  @override
+  String get swapAction => '兑换';
+
+  @override
+  String get swapEstimatedFee => '预估手续费';
+
+  @override
+  String get swapUseAll => '全部使用';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1223,4 +1223,26 @@ class L10nZh extends L10n {
 
   @override
   String get swapUseAll => '全部使用';
+
+  @override
+  String swapMinimum(String amount) {
+    return '最低: $amount';
+  }
+
+  @override
+  String get swapProcessing => '兑换处理中...';
+
+  @override
+  String get swapSuccess => '兑换完成';
+
+  @override
+  String get swapErrorInsufficient => '余额不足';
+
+  @override
+  String get swapErrorExpired => '报价已过期';
+
+  @override
+  String swapErrorGeneric(String error) {
+    return '兑换错误: $error';
+  }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -567,5 +567,11 @@
   "swapTo": "Para",
   "swapAction": "Trocar",
   "swapEstimatedFee": "Taxa estimada",
-  "swapUseAll": "Usar tudo"
+  "swapUseAll": "Usar tudo",
+  "swapMinimum": "Mínimo: {amount}",
+  "swapProcessing": "Processando swap...",
+  "swapSuccess": "Swap concluído",
+  "swapErrorInsufficient": "Saldo insuficiente",
+  "swapErrorExpired": "A cotação expirou",
+  "swapErrorGeneric": "Erro no swap: {error}"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "Pagamento recebido",
   "requestDescriptionHint": "Descrição (opcional)",
   "universal": "Universal",
-  "copiedToClipboard": "Copiado para a área de transferência"
+  "copiedToClipboard": "Copiado para a área de transferência",
+
+  "swap": "Trocar",
+  "swapDescription": "Converter entre sats e USD",
+  "swapFrom": "De",
+  "swapTo": "Para",
+  "swapAction": "Trocar",
+  "swapEstimatedFee": "Taxa estimada",
+  "swapUseAll": "Usar tudo"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "Платёж получен",
   "requestDescriptionHint": "Описание (необязательно)",
   "universal": "Универсальный",
-  "copiedToClipboard": "Скопировано в буфер обмена"
+  "copiedToClipboard": "Скопировано в буфер обмена",
+
+  "swap": "Обменять",
+  "swapDescription": "Конвертировать между sats и USD",
+  "swapFrom": "Из",
+  "swapTo": "В",
+  "swapAction": "Обменять",
+  "swapEstimatedFee": "Ориентировочная комиссия",
+  "swapUseAll": "Использовать всё"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -567,5 +567,11 @@
   "swapTo": "В",
   "swapAction": "Обменять",
   "swapEstimatedFee": "Ориентировочная комиссия",
-  "swapUseAll": "Использовать всё"
+  "swapUseAll": "Использовать всё",
+  "swapMinimum": "Минимум: {amount}",
+  "swapProcessing": "Обработка обмена...",
+  "swapSuccess": "Обмен завершён",
+  "swapErrorInsufficient": "Недостаточный баланс",
+  "swapErrorExpired": "Котировка истекла",
+  "swapErrorGeneric": "Ошибка обмена: {error}"
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -567,5 +567,11 @@
   "swapTo": "Kwenda",
   "swapAction": "Badilisha",
   "swapEstimatedFee": "Ada inayokadiriwa",
-  "swapUseAll": "Tumia yote"
+  "swapUseAll": "Tumia yote",
+  "swapMinimum": "Kiwango cha chini: {amount}",
+  "swapProcessing": "Inashughulikia ubadilishaji...",
+  "swapSuccess": "Ubadilishaji umekamilika",
+  "swapErrorInsufficient": "Salio haitoshi",
+  "swapErrorExpired": "Bei imeisha muda",
+  "swapErrorGeneric": "Kosa la ubadilishaji: {error}"
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "Malipo limepokelewa",
   "requestDescriptionHint": "Maelezo (si lazima)",
   "universal": "Universal",
-  "copiedToClipboard": "Imenakiliwa kwenye ubao wa kunakili"
+  "copiedToClipboard": "Imenakiliwa kwenye ubao wa kunakili",
+
+  "swap": "Badilisha",
+  "swapDescription": "Badilisha kati ya sats na USD",
+  "swapFrom": "Kutoka",
+  "swapTo": "Kwenda",
+  "swapAction": "Badilisha",
+  "swapEstimatedFee": "Ada inayokadiriwa",
+  "swapUseAll": "Tumia yote"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -567,5 +567,11 @@
   "swapTo": "到",
   "swapAction": "兑换",
   "swapEstimatedFee": "预估手续费",
-  "swapUseAll": "全部使用"
+  "swapUseAll": "全部使用",
+  "swapMinimum": "最低: {amount}",
+  "swapProcessing": "兑换处理中...",
+  "swapSuccess": "兑换完成",
+  "swapErrorInsufficient": "余额不足",
+  "swapErrorExpired": "报价已过期",
+  "swapErrorGeneric": "兑换错误: {error}"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -559,5 +559,13 @@
   "requestPaymentReceived": "已收到付款",
   "requestDescriptionHint": "描述（可选）",
   "universal": "通用",
-  "copiedToClipboard": "已复制到剪贴板"
+  "copiedToClipboard": "已复制到剪贴板",
+
+  "swap": "兑换",
+  "swapDescription": "在 Sats 和 USD 之间转换",
+  "swapFrom": "从",
+  "swapTo": "到",
+  "swapAction": "兑换",
+  "swapEstimatedFee": "预估手续费",
+  "swapUseAll": "全部使用"
 }

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1546,7 +1546,7 @@ class WalletProvider extends ChangeNotifier {
       );
       final tx = txs.cast<Transaction?>().firstWhere(
         (t) => t!.amount == amount && !_txMetaStorage.has(t.id),
-        orElse: () => txs.isNotEmpty ? txs.first : null,
+        orElse: () => null,
       );
       if (tx != null) {
         await _txMetaStorage.save(
@@ -1554,6 +1554,8 @@ class WalletProvider extends ChangeNotifier {
           TransactionMeta(type: TransactionType.lightning, invoice: invoice),
         );
         debugPrint('Swap melt metadata guardada para tx ${tx.id}');
+      } else {
+        debugPrint('No matching untagged outgoing tx found for amount $amount');
       }
     } catch (e) {
       debugPrint('Error guardando swap melt metadata: $e');
@@ -1570,7 +1572,7 @@ class WalletProvider extends ChangeNotifier {
       );
       final tx = txs.cast<Transaction?>().firstWhere(
         (t) => t!.amount == amount && !_txMetaStorage.has(t.id),
-        orElse: () => txs.isNotEmpty ? txs.first : null,
+        orElse: () => null,
       );
       if (tx != null) {
         await _txMetaStorage.save(
@@ -1578,10 +1580,13 @@ class WalletProvider extends ChangeNotifier {
           TransactionMeta(type: TransactionType.lightning, invoice: invoice),
         );
         debugPrint('Swap mint metadata guardada para tx ${tx.id}');
+      } else {
+        debugPrint('No matching untagged incoming tx found for amount $amount');
       }
     } catch (e) {
       debugPrint('Error guardando swap mint metadata: $e');
     }
+    notifyListeners();
   }
 
   // ============================================================

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1537,6 +1537,53 @@ class WalletProvider extends ChangeNotifier {
     }
   }
 
+  /// Guarda metadata para el lado melt (enviado) de un swap.
+  /// Busca la tx outgoing más reciente que coincida con el monto.
+  Future<void> saveSwapMeltMetadata(Wallet wallet, String invoice, BigInt amount) async {
+    try {
+      final txs = await wallet.listTransactions(
+        direction: TransactionDirection.outgoing,
+      );
+      final tx = txs.cast<Transaction?>().firstWhere(
+        (t) => t!.amount == amount && !_txMetaStorage.has(t.id),
+        orElse: () => txs.isNotEmpty ? txs.first : null,
+      );
+      if (tx != null) {
+        await _txMetaStorage.save(
+          tx.id,
+          TransactionMeta(type: TransactionType.lightning, invoice: invoice),
+        );
+        debugPrint('Swap melt metadata guardada para tx ${tx.id}');
+      }
+    } catch (e) {
+      debugPrint('Error guardando swap melt metadata: $e');
+    }
+    notifyListeners();
+  }
+
+  /// Guarda metadata para el lado mint (recibido) de un swap.
+  /// Busca la tx incoming más reciente que coincida con el monto.
+  Future<void> saveSwapMintMetadata(Wallet wallet, String invoice, BigInt amount) async {
+    try {
+      final txs = await wallet.listTransactions(
+        direction: TransactionDirection.incoming,
+      );
+      final tx = txs.cast<Transaction?>().firstWhere(
+        (t) => t!.amount == amount && !_txMetaStorage.has(t.id),
+        orElse: () => txs.isNotEmpty ? txs.first : null,
+      );
+      if (tx != null) {
+        await _txMetaStorage.save(
+          tx.id,
+          TransactionMeta(type: TransactionType.lightning, invoice: invoice),
+        );
+        debugPrint('Swap mint metadata guardada para tx ${tx.id}');
+      }
+    } catch (e) {
+      debugPrint('Error guardando swap mint metadata: $e');
+    }
+  }
+
   // ============================================================
   // HISTORIAL
   // ============================================================

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -80,7 +80,7 @@ class _SwapScreenState extends State<SwapScreen>
 
   Future<void> _loadBalances() async {
     final walletProvider = context.read<WalletProvider>();
-    final mintUrl = walletProvider.activeMintUrl;
+    final mintUrl = WalletProvider.cubaBitcoinMint;
     if (mintUrl == null) return;
 
     try {
@@ -262,7 +262,7 @@ class _SwapScreenState extends State<SwapScreen>
   /// muestra fee en modal de confirmación.
   Future<void> _startSwap() async {
     final walletProvider = context.read<WalletProvider>();
-    final mintUrl = walletProvider.activeMintUrl;
+    final mintUrl = WalletProvider.cubaBitcoinMint;
     if (mintUrl == null) return;
 
     final destAmount = _getDestAmount();
@@ -372,6 +372,8 @@ class _SwapScreenState extends State<SwapScreen>
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
+      isDismissible: false,
+      enableDrag: false,
       builder: (ctx) => Container(
         padding: const EdgeInsets.all(AppDimensions.paddingMedium),
         decoration: BoxDecoration(
@@ -614,13 +616,27 @@ class _SwapScreenState extends State<SwapScreen>
             icon: const Icon(LucideIcons.arrowLeft, color: Colors.white),
             onPressed: () => Navigator.pop(context),
           ),
-          title: Text(
-            l10n.swap,
-            style: const TextStyle(
-              fontFamily: 'Inter',
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-            ),
+          title: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                l10n.swap,
+                style: const TextStyle(
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                ),
+              ),
+              Text(
+                WalletProvider.cubaBitcoinMint.replaceFirst('https://', ''),
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                  color: AppColors.textSecondary.withValues(alpha: 0.6),
+                ),
+              ),
+            ],
           ),
         ),
         body: SafeArea(

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -1,0 +1,612 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:elcaju/l10n/app_localizations.dart';
+import '../../core/constants/colors.dart';
+import '../../core/constants/dimensions.dart';
+import '../../core/utils/formatters.dart';
+import '../../core/services/price_service.dart';
+import '../../widgets/common/gradient_background.dart';
+import '../../widgets/common/glass_card.dart';
+import '../../widgets/common/primary_button.dart';
+import '../../providers/wallet_provider.dart';
+import '../../providers/price_provider.dart';
+
+class SwapScreen extends StatefulWidget {
+  const SwapScreen({super.key});
+
+  @override
+  State<SwapScreen> createState() => _SwapScreenState();
+}
+
+class _SwapScreenState extends State<SwapScreen>
+    with SingleTickerProviderStateMixin {
+  // true = sats → usd, false = usd → sats
+  bool _isSatsToUsd = true;
+  final _amountController = TextEditingController();
+  String _convertedAmount = '';
+
+  late AnimationController _flipController;
+  late Animation<double> _flipAnimation;
+
+  BigInt _satsBalance = BigInt.zero;
+  BigInt _usdBalance = BigInt.zero;
+
+  List<double> _chartData = [];
+  bool _isLoadingChart = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _flipController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _flipAnimation = Tween<double>(begin: 0.0, end: 0.5).animate(
+      CurvedAnimation(parent: _flipController, curve: Curves.easeInOut),
+    );
+    _amountController.addListener(_calculateConversion);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadBalances();
+      _loadChartData();
+    });
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _flipController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadBalances() async {
+    final walletProvider = context.read<WalletProvider>();
+    final mintUrl = walletProvider.activeMintUrl;
+    if (mintUrl == null) return;
+
+    final balances = await walletProvider.getBalancesForMint(mintUrl);
+    if (mounted) {
+      setState(() {
+        _satsBalance = balances['sat'] ?? BigInt.zero;
+        _usdBalance = balances['usd'] ?? BigInt.zero;
+      });
+    }
+  }
+
+  Future<void> _loadChartData() async {
+    try {
+      final prices = await PriceService.getHistoricalPrices(range: 'ONE_DAY');
+      if (mounted && prices.isNotEmpty) {
+        setState(() {
+          _chartData = prices.map((p) => p.priceUsd).toList();
+          _isLoadingChart = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _chartData = _generateMockData();
+          _isLoadingChart = false;
+        });
+      }
+    }
+  }
+
+  List<double> _generateMockData() {
+    final priceProvider = context.read<PriceProvider>();
+    final basePrice = priceProvider.btcPriceUsd ?? 65000;
+    final rng = Random();
+    return List.generate(24, (i) {
+      return basePrice + (rng.nextDouble() - 0.48) * basePrice * 0.02;
+    });
+  }
+
+  void _calculateConversion() {
+    final text = _amountController.text;
+    if (text.isEmpty) {
+      setState(() => _convertedAmount = '');
+      return;
+    }
+
+    final priceProvider = context.read<PriceProvider>();
+    final btcPrice = priceProvider.btcPriceUsd;
+    if (btcPrice == null || btcPrice == 0) {
+      setState(() => _convertedAmount = '...');
+      return;
+    }
+
+    try {
+      if (_isSatsToUsd) {
+        final sats = int.tryParse(text) ?? 0;
+        final usdAmount = sats / 100000000 * btcPrice;
+        setState(() {
+          _convertedAmount = usdAmount < 0.01 && usdAmount > 0
+              ? '< \$0.01'
+              : '\$${usdAmount.toStringAsFixed(2)}';
+        });
+      } else {
+        final usd = double.tryParse(text) ?? 0;
+        final sats = (usd / btcPrice * 100000000).round();
+        setState(() {
+          _convertedAmount = '${NumberFormat('#,###').format(sats)} sat';
+        });
+      }
+    } catch (_) {
+      setState(() => _convertedAmount = '...');
+    }
+  }
+
+  void _flipDirection() {
+    HapticFeedback.mediumImpact();
+    if (_isSatsToUsd) {
+      _flipController.forward();
+    } else {
+      _flipController.reverse();
+    }
+    setState(() {
+      _isSatsToUsd = !_isSatsToUsd;
+      _amountController.clear();
+      _convertedAmount = '';
+    });
+  }
+
+  void _setQuickAmount(String amount) {
+    _amountController.text = amount;
+    _amountController.selection = TextSelection.fromPosition(
+      TextPosition(offset: amount.length),
+    );
+  }
+
+  void _setMaxAmount() {
+    if (_isSatsToUsd) {
+      _setQuickAmount(_satsBalance.toString());
+    } else {
+      final usd = _usdBalance.toDouble() / 100;
+      _setQuickAmount(usd.toStringAsFixed(2));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final priceProvider = context.watch<PriceProvider>();
+
+    return GradientBackground(
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(LucideIcons.arrowLeft, color: Colors.white),
+            onPressed: () => Navigator.pop(context),
+          ),
+          title: Text(
+            l10n.swap,
+            style: const TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+          centerTitle: true,
+        ),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+            child: Column(
+              children: [
+                _buildPriceChart(priceProvider),
+                const SizedBox(height: AppDimensions.paddingMedium),
+                const SizedBox(height: AppDimensions.paddingLarge),
+                _buildFromCard(l10n),
+                _buildFlipButton(),
+                _buildToCard(l10n),
+                const SizedBox(height: AppDimensions.paddingMedium),
+                const SizedBox(height: AppDimensions.paddingLarge),
+                PrimaryButton(
+                  text: l10n.swapAction,
+                  onPressed: _amountController.text.isNotEmpty
+                      ? () {
+                          // TODO: implement swap logic
+                          HapticFeedback.heavyImpact();
+                        }
+                      : null,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // --- Widgets ---
+
+  Widget _buildPriceChart(PriceProvider priceProvider) {
+    final btcPrice = priceProvider.btcPriceUsd;
+    final priceStr = btcPrice != null
+        ? '\$${NumberFormat('#,###').format(btcPrice.round())}'
+        : '...';
+
+    String rateStr = '...';
+    if (btcPrice != null && btcPrice > 0) {
+      final satsPerDollar = (100000000 / btcPrice).round();
+      rateStr = '1 USD ≈ ${NumberFormat('#,###').format(satsPerDollar)} sats';
+    }
+
+    final isUpTrend =
+        _chartData.length >= 2 && _chartData.last >= _chartData.first;
+    final trendColor = isUpTrend ? AppColors.success : AppColors.error;
+
+    return Column(
+      children: [
+        // Price
+        Text(
+          priceStr,
+          style: const TextStyle(
+            fontFamily: 'Inter',
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          'USD',
+          style: TextStyle(
+            fontFamily: 'Inter',
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            color: AppColors.textSecondary.withValues(alpha: 0.6),
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        // Sparkline (sin contenedor, integrado)
+        SizedBox(
+          height: 40,
+          width: double.infinity,
+          child: _isLoadingChart
+              ? Center(
+                  child: SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 1.5,
+                      color: AppColors.textSecondary.withValues(alpha: 0.3),
+                    ),
+                  ),
+                )
+              : CustomPaint(
+                  painter: _SparklinePainter(
+                    data: _chartData,
+                    lineColor: trendColor,
+                    fillColor: trendColor.withValues(alpha: 0.08),
+                  ),
+                ),
+        ),
+        const SizedBox(height: 8),
+
+        // Exchange rate
+        Text(
+          rateStr,
+          style: TextStyle(
+            fontFamily: 'Inter',
+            fontSize: 13,
+            fontWeight: FontWeight.w500,
+            color: AppColors.textSecondary.withValues(alpha: 0.7),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFromCard(L10n l10n) {
+    final fromSymbol = _isSatsToUsd ? '₿' : '\$';
+    final fromLabel = _isSatsToUsd ? 'sats' : 'USD';
+    final fromBalance = _isSatsToUsd
+        ? UnitFormatter.formatBalance(_satsBalance, 'sat')
+        : UnitFormatter.formatBalance(_usdBalance, 'usd');
+    final fromUnit = _isSatsToUsd ? 'sat' : 'USD';
+
+    return GlassCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Label + Balance en la misma línea
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                l10n.swapFrom,
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textSecondary.withValues(alpha: 0.6),
+                ),
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '${l10n.balance}: $fromBalance $fromUnit',
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 12,
+                      color: AppColors.textSecondary.withValues(alpha: 0.6),
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  GestureDetector(
+                    onTap: _setMaxAmount,
+                    child: Text(
+                      l10n.swapUseAll,
+                      style: const TextStyle(
+                        fontFamily: 'Inter',
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.primaryAction,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              // Unit pill
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '$fromSymbol $fromLabel',
+                  style: const TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              // Amount input
+              Expanded(
+                child: TextField(
+                  key: ValueKey('from_$_isSatsToUsd'),
+                  controller: _amountController,
+                  keyboardType: TextInputType.numberWithOptions(
+                    decimal: !_isSatsToUsd,
+                  ),
+                  style: const TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                  textAlign: TextAlign.right,
+                  decoration: InputDecoration(
+                    hintText: '0',
+                    hintStyle: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white.withValues(alpha: 0.2),
+                    ),
+                    border: InputBorder.none,
+                    contentPadding: EdgeInsets.zero,
+                    isDense: true,
+                  ),
+                  inputFormatters: [
+                    if (_isSatsToUsd)
+                      FilteringTextInputFormatter.digitsOnly
+                    else
+                      FilteringTextInputFormatter.allow(
+                          RegExp(r'^\d*\.?\d{0,2}')),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFlipButton() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Center(
+        child: GestureDetector(
+          onTap: _flipDirection,
+          child: RotationTransition(
+            turns: _flipAnimation,
+            child: Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                gradient: const LinearGradient(
+                  colors: AppColors.buttonGradient,
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                shape: BoxShape.circle,
+                boxShadow: [
+                  BoxShadow(
+                    color: AppColors.primaryAction.withValues(alpha: 0.3),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: const Icon(
+                LucideIcons.arrowUpDown,
+                color: Colors.white,
+                size: 20,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildToCard(L10n l10n) {
+    final toSymbol = _isSatsToUsd ? '\$' : '₿';
+    final toLabel = _isSatsToUsd ? 'USD' : 'sats';
+    final toBalance = _isSatsToUsd
+        ? UnitFormatter.formatBalance(_usdBalance, 'usd')
+        : UnitFormatter.formatBalance(_satsBalance, 'sat');
+    final toUnit = _isSatsToUsd ? 'USD' : 'sat';
+
+    return GlassCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Label + Balance en la misma línea
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                l10n.swapTo,
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textSecondary.withValues(alpha: 0.6),
+                ),
+              ),
+              Text(
+                '${l10n.balance}: $toBalance $toUnit',
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 12,
+                  color: AppColors.textSecondary.withValues(alpha: 0.6),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '$toSymbol $toLabel',
+                  style: const TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  _convertedAmount.isEmpty ? '≈ 0' : '≈ $_convertedAmount',
+                  textAlign: TextAlign.right,
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white.withValues(alpha: 0.7),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+}
+
+// --- Private widgets ---
+
+class _SparklinePainter extends CustomPainter {
+  final List<double> data;
+  final Color lineColor;
+  final Color fillColor;
+
+  _SparklinePainter({
+    required this.data,
+    required this.lineColor,
+    required this.fillColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (data.length < 2) return;
+
+    final minVal = data.reduce(min);
+    final maxVal = data.reduce(max);
+    final range = maxVal - minVal;
+    if (range == 0) return;
+
+    // Calculate points
+    final points = <Offset>[];
+    for (int i = 0; i < data.length; i++) {
+      final x = (i / (data.length - 1)) * size.width;
+      final y = size.height -
+          ((data[i] - minVal) / range) * size.height * 0.85 -
+          size.height * 0.075;
+      points.add(Offset(x, y));
+    }
+
+    // Build smooth path using cubic bezier
+    final path = Path();
+    final fillPath = Path();
+
+    path.moveTo(points[0].dx, points[0].dy);
+    fillPath.moveTo(points[0].dx, size.height);
+    fillPath.lineTo(points[0].dx, points[0].dy);
+
+    for (int i = 0; i < points.length - 1; i++) {
+      final p0 = points[i];
+      final p1 = points[i + 1];
+      final midX = (p0.dx + p1.dx) / 2;
+      path.cubicTo(midX, p0.dy, midX, p1.dy, p1.dx, p1.dy);
+      fillPath.cubicTo(midX, p0.dy, midX, p1.dy, p1.dx, p1.dy);
+    }
+
+    // Fill gradient
+    fillPath.lineTo(points.last.dx, size.height);
+    fillPath.close();
+    canvas.drawPath(fillPath, Paint()..color = fillColor);
+
+    // Smooth line
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = lineColor
+        ..strokeWidth = 1.5
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _SparklinePainter oldDelegate) =>
+      oldDelegate.data != data || oldDelegate.lineColor != lineColor;
+}
+
+

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -283,9 +283,18 @@ class _SwapScreenState extends State<SwapScreen>
       _mintSubscription = destWallet.mint(
         amount: destAmount,
       ).listen(
-        (quote) {
+        (quote) async {
           if (quote.state == MintQuoteState.unpaid && !completer.isCompleted) {
             completer.complete(quote.request);
+          }
+          if (quote.state == MintQuoteState.issued) {
+            final wp = context.read<WalletProvider>();
+            await wp.saveSwapMintMetadata(
+              destWallet, quote.request, destAmount,
+            );
+            if (mounted) _loadBalances();
+            _mintSubscription?.cancel();
+            _mintSubscription = null;
           }
           if (quote.state == MintQuoteState.error && !completer.isCompleted) {
             completer.completeError(
@@ -296,9 +305,20 @@ class _SwapScreenState extends State<SwapScreen>
         onError: (e) {
           if (!completer.isCompleted) completer.completeError(e);
         },
+        onDone: () {
+          if (!completer.isCompleted) {
+            completer.completeError(Exception('Mint quote stream closed unexpectedly'));
+          }
+        },
       );
 
-      invoice = await completer.future;
+      invoice = await completer.future.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          _mintSubscription?.cancel();
+          throw Exception('Mint quote creation timed out');
+        },
+      );
 
       // 3. Obtener melt quote en wallet origen → fee
       final meltQuote = await srcWallet.meltQuote(request: invoice);
@@ -525,7 +545,8 @@ class _SwapScreenState extends State<SwapScreen>
         srcWallet, invoice, meltQuote.amount,
       );
 
-      _mintSubscription?.cancel();
+      // No cancelar _mintSubscription: el listener espera el estado
+      // `issued` para guardar metadata del mint y recargar balances.
 
       if (!mounted) return;
 
@@ -534,15 +555,6 @@ class _SwapScreenState extends State<SwapScreen>
       if (!mounted) return;
 
       walletProvider.confettiController.fire();
-
-      // En background: esperar a que CDK procese el mint,
-      // guardar metadata del lado recibido y recargar balances
-      Future.delayed(const Duration(seconds: 3), () async {
-        await walletProvider.saveSwapMintMetadata(
-          destWallet, invoice, destAmount,
-        );
-        if (mounted) _loadBalances();
-      });
 
       // Limpiar campos
       _isUpdating = true;
@@ -564,6 +576,8 @@ class _SwapScreenState extends State<SwapScreen>
         ),
       );
     } catch (e) {
+      _mintSubscription?.cancel();
+      _mintSubscription = null;
       if (!mounted) return;
       final errorStr = e.toString().toLowerCase();
       setState(() {
@@ -576,9 +590,6 @@ class _SwapScreenState extends State<SwapScreen>
           _swapError = l10n.swapErrorGeneric(e.toString());
         }
       });
-    } finally {
-      _mintSubscription?.cancel();
-      _mintSubscription = null;
     }
   }
 

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -246,7 +246,7 @@ class _SwapScreenState extends State<SwapScreen>
 
   /// Determina el monto destino en BigInt (centavos para USD, sats para sat).
   BigInt _getDestAmount() {
-    final destText = _isSatsToUsd ? _toController.text : _toController.text;
+    final destText = _toController.text;
     final destUnit = _isSatsToUsd ? 'usd' : 'sat';
     return UnitFormatter.parseUserInput(destText, destUnit);
   }
@@ -288,11 +288,14 @@ class _SwapScreenState extends State<SwapScreen>
             completer.complete(quote.request);
           }
           if (quote.state == MintQuoteState.issued) {
-            final wp = context.read<WalletProvider>();
-            await wp.saveSwapMintMetadata(
-              destWallet, quote.request, destAmount,
-            );
-            if (mounted) _loadBalances();
+            try {
+              await walletProvider.saveSwapMintMetadata(
+                destWallet, quote.request, destAmount,
+              );
+              if (mounted) _loadBalances();
+            } catch (e) {
+              debugPrint('Error saving swap mint metadata: $e');
+            }
             _mintSubscription?.cancel();
             _mintSubscription = null;
           }

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -161,11 +161,11 @@ class _SwapScreenState extends State<SwapScreen>
       String result;
       if (sourceIsSats) {
         final sats = int.tryParse(text) ?? 0;
-        final usd = sats / 100000000 * btcPrice;
-        result = usd == 0 ? '' : usd.toStringAsFixed(2);
+        final cents = ((sats / 100000000) * btcPrice * 100).floor();
+        result = cents == 0 ? '' : (cents / 100).toStringAsFixed(2);
       } else {
         final usd = double.tryParse(text) ?? 0;
-        final sats = (usd / btcPrice * 100000000).round();
+        final sats = (usd / btcPrice * 100000000).floor();
         result = sats == 0 ? '' : sats.toString();
       }
 

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -83,12 +83,15 @@ class _SwapScreenState extends State<SwapScreen>
     final mintUrl = walletProvider.activeMintUrl;
     if (mintUrl == null) return;
 
-    final balances = await walletProvider.getBalancesForMint(mintUrl);
-    if (mounted) {
+    try {
+      final balances = await walletProvider.getBalancesForMint(mintUrl);
+      if (!mounted) return;
       setState(() {
         _satsBalance = balances['sat'] ?? BigInt.zero;
         _usdBalance = balances['usd'] ?? BigInt.zero;
       });
+    } catch (e) {
+      debugPrint('Error loading swap balances: $e');
     }
   }
 
@@ -446,7 +449,7 @@ class _SwapScreenState extends State<SwapScreen>
 
             // Fee
             Text(
-              '+ ~${UnitFormatter.formatBalance(meltQuote.feeReserve, _srcUnit)} $srcUnitLabel fee',
+              '+ ~${UnitFormatter.formatBalance(meltQuote.feeReserve, _srcUnit)} $srcUnitLabel ${l10n.fee}',
               style: TextStyle(
                 fontFamily: 'Inter',
                 fontSize: 14,
@@ -457,7 +460,7 @@ class _SwapScreenState extends State<SwapScreen>
 
             // Total
             Text(
-              'Total: ${UnitFormatter.formatBalance(total, _srcUnit)} $srcUnitLabel',
+              '${l10n.total} ${UnitFormatter.formatBalance(total, _srcUnit)} $srcUnitLabel',
               style: const TextStyle(
                 fontFamily: 'Inter',
                 fontSize: 16,

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -9,6 +10,7 @@ import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';
 import '../../core/utils/formatters.dart';
 import '../../core/services/price_service.dart';
+import '../../src/rust/api/wallet.dart';
 import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/common/primary_button.dart';
@@ -26,8 +28,13 @@ class _SwapScreenState extends State<SwapScreen>
     with SingleTickerProviderStateMixin {
   // true = sats → usd, false = usd → sats
   bool _isSatsToUsd = true;
-  final _amountController = TextEditingController();
-  String _convertedAmount = '';
+  final _fromController = TextEditingController();
+  final _toController = TextEditingController();
+
+  // Cuál campo se editó último: true = from, false = to
+  bool _lastEditedFrom = true;
+  // Evita loops infinitos entre listeners
+  bool _isUpdating = false;
 
   late AnimationController _flipController;
   late Animation<double> _flipAnimation;
@@ -37,6 +44,12 @@ class _SwapScreenState extends State<SwapScreen>
 
   List<double> _chartData = [];
   bool _isLoadingChart = true;
+
+  // --- Swap state ---
+  bool _isSwapping = false;
+  String? _swapError;
+  // Suscripciones locales (NO usa los globales del provider)
+  StreamSubscription<MintQuote>? _mintSubscription;
 
   @override
   void initState() {
@@ -48,7 +61,8 @@ class _SwapScreenState extends State<SwapScreen>
     _flipAnimation = Tween<double>(begin: 0.0, end: 0.5).animate(
       CurvedAnimation(parent: _flipController, curve: Curves.easeInOut),
     );
-    _amountController.addListener(_calculateConversion);
+    _fromController.addListener(_onFromChanged);
+    _toController.addListener(_onToChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadBalances();
       _loadChartData();
@@ -57,7 +71,9 @@ class _SwapScreenState extends State<SwapScreen>
 
   @override
   void dispose() {
-    _amountController.dispose();
+    _mintSubscription?.cancel();
+    _fromController.dispose();
+    _toController.dispose();
     _flipController.dispose();
     super.dispose();
   }
@@ -104,38 +120,58 @@ class _SwapScreenState extends State<SwapScreen>
     });
   }
 
-  void _calculateConversion() {
-    final text = _amountController.text;
+  void _onFromChanged() {
+    if (_isUpdating) return;
+    _lastEditedFrom = true;
+    _syncConversion(fromSource: true);
+  }
+
+  void _onToChanged() {
+    if (_isUpdating) return;
+    _lastEditedFrom = false;
+    _syncConversion(fromSource: false);
+  }
+
+  /// Calcula el campo opuesto basado en el campo editado
+  void _syncConversion({required bool fromSource}) {
+    final source = fromSource ? _fromController : _toController;
+    final target = fromSource ? _toController : _fromController;
+    final text = source.text;
+
     if (text.isEmpty) {
-      setState(() => _convertedAmount = '');
+      _isUpdating = true;
+      target.text = '';
+      _isUpdating = false;
+      setState(() {});
       return;
     }
 
     final priceProvider = context.read<PriceProvider>();
     final btcPrice = priceProvider.btcPriceUsd;
-    if (btcPrice == null || btcPrice == 0) {
-      setState(() => _convertedAmount = '...');
-      return;
-    }
+    if (btcPrice == null || btcPrice == 0) return;
 
     try {
-      if (_isSatsToUsd) {
+      // Determinar si el source es sats o usd
+      final sourceIsSats =
+          (fromSource && _isSatsToUsd) || (!fromSource && !_isSatsToUsd);
+
+      String result;
+      if (sourceIsSats) {
         final sats = int.tryParse(text) ?? 0;
-        final usdAmount = sats / 100000000 * btcPrice;
-        setState(() {
-          _convertedAmount = usdAmount < 0.01 && usdAmount > 0
-              ? '< \$0.01'
-              : '\$${usdAmount.toStringAsFixed(2)}';
-        });
+        final usd = sats / 100000000 * btcPrice;
+        result = usd == 0 ? '' : usd.toStringAsFixed(2);
       } else {
         final usd = double.tryParse(text) ?? 0;
         final sats = (usd / btcPrice * 100000000).round();
-        setState(() {
-          _convertedAmount = '${NumberFormat('#,###').format(sats)} sat';
-        });
+        result = sats == 0 ? '' : sats.toString();
       }
+
+      _isUpdating = true;
+      target.text = result;
+      _isUpdating = false;
+      setState(() {});
     } catch (_) {
-      setState(() => _convertedAmount = '...');
+      // ignorar errores de parseo parcial
     }
   }
 
@@ -146,26 +182,403 @@ class _SwapScreenState extends State<SwapScreen>
     } else {
       _flipController.reverse();
     }
+
+    // Intercambiar valores entre campos
+    final fromText = _fromController.text;
+    final toText = _toController.text;
+
+    _isUpdating = true;
     setState(() {
       _isSatsToUsd = !_isSatsToUsd;
-      _amountController.clear();
-      _convertedAmount = '';
+      _fromController.text = toText;
+      _toController.text = fromText;
+      _lastEditedFrom = !_lastEditedFrom;
     });
-  }
-
-  void _setQuickAmount(String amount) {
-    _amountController.text = amount;
-    _amountController.selection = TextSelection.fromPosition(
-      TextPosition(offset: amount.length),
-    );
+    _isUpdating = false;
   }
 
   void _setMaxAmount() {
     if (_isSatsToUsd) {
-      _setQuickAmount(_satsBalance.toString());
+      _fromController.text = _satsBalance.toString();
     } else {
       final usd = _usdBalance.toDouble() / 100;
-      _setQuickAmount(usd.toStringAsFixed(2));
+      _fromController.text = usd.toStringAsFixed(2);
+    }
+    _lastEditedFrom = true;
+  }
+
+  // --- Validación de mínimos del mint ---
+  static const double _minUsd = 0.01;
+  static const int _minSats = 1;
+
+  /// Valida que ambos lados cumplan los mínimos del mint.
+  /// Retorna null si es válido, o el mensaje de error si no.
+  String? _validateMinimums(L10n l10n) {
+    if (_fromController.text.isEmpty || _toController.text.isEmpty) return null;
+
+    final priceProvider = context.read<PriceProvider>();
+    final btcPrice = priceProvider.btcPriceUsd;
+    if (btcPrice == null || btcPrice == 0) return null;
+
+    if (_isSatsToUsd) {
+      // from=sats, to=usd → verificar que USD >= 0.01
+      final usd = double.tryParse(_toController.text) ?? 0;
+      if (usd < _minUsd) {
+        // Calcular mínimo de sats necesario
+        final minSatsNeeded = ((_minUsd / btcPrice) * 100000000).ceil();
+        return l10n.swapMinimum('$minSatsNeeded sats');
+      }
+    } else {
+      // from=usd, to=sats → verificar que sats >= 1 y USD >= 0.01
+      final usd = double.tryParse(_fromController.text) ?? 0;
+      final sats = int.tryParse(_toController.text) ?? 0;
+      if (usd < _minUsd) {
+        return l10n.swapMinimum('\$${_minUsd.toStringAsFixed(2)}');
+      }
+      if (sats < _minSats) {
+        return l10n.swapMinimum('$_minSats sat');
+      }
+    }
+    return null;
+  }
+
+  // --- Swap logic ---
+
+  /// Determina el monto destino en BigInt (centavos para USD, sats para sat).
+  BigInt _getDestAmount() {
+    final destText = _isSatsToUsd ? _toController.text : _toController.text;
+    final destUnit = _isSatsToUsd ? 'usd' : 'sat';
+    return UnitFormatter.parseUserInput(destText, destUnit);
+  }
+
+  /// Determina unidades de origen y destino.
+  String get _srcUnit => _isSatsToUsd ? 'sat' : 'usd';
+  String get _destUnit => _isSatsToUsd ? 'usd' : 'sat';
+
+  /// Inicia el swap: crea mint quote en destino, obtiene melt quote en origen,
+  /// muestra fee en modal de confirmación.
+  Future<void> _startSwap() async {
+    final walletProvider = context.read<WalletProvider>();
+    final mintUrl = walletProvider.activeMintUrl;
+    if (mintUrl == null) return;
+
+    final destAmount = _getDestAmount();
+    if (destAmount <= BigInt.zero) return;
+
+    setState(() {
+      _isSwapping = true;
+      _swapError = null;
+    });
+
+    try {
+      // 1. Obtener wallets directamente (sin cambiar activeUnit)
+      final destWallet = await walletProvider.getWallet(mintUrl, _destUnit);
+      final srcWallet = await walletProvider.getWallet(mintUrl, _srcUnit);
+
+      // 2. Crear mint quote en wallet destino → obtener invoice BOLT11
+      String? invoice;
+      final completer = Completer<String>();
+
+      _mintSubscription?.cancel();
+      _mintSubscription = destWallet.mint(
+        amount: destAmount,
+      ).listen(
+        (quote) {
+          if (quote.state == MintQuoteState.unpaid && !completer.isCompleted) {
+            completer.complete(quote.request);
+          }
+          if (quote.state == MintQuoteState.error && !completer.isCompleted) {
+            completer.completeError(
+              Exception(quote.error ?? 'Error creating mint quote'),
+            );
+          }
+        },
+        onError: (e) {
+          if (!completer.isCompleted) completer.completeError(e);
+        },
+      );
+
+      invoice = await completer.future;
+
+      // 3. Obtener melt quote en wallet origen → fee
+      final meltQuote = await srcWallet.meltQuote(request: invoice);
+
+      if (!mounted) return;
+      setState(() => _isSwapping = false);
+
+      // 4. Mostrar confirmación con fee
+      _showSwapConfirmation(
+        meltQuote: meltQuote,
+        srcWallet: srcWallet,
+        destWallet: destWallet,
+        destAmount: destAmount,
+      );
+    } catch (e) {
+      _mintSubscription?.cancel();
+      if (!mounted) return;
+      final l10n = L10n.of(context)!;
+      final errorStr = e.toString().toLowerCase();
+      setState(() {
+        _isSwapping = false;
+        if (errorStr.contains('insufficient') || errorStr.contains('not enough')) {
+          _swapError = l10n.swapErrorInsufficient;
+        } else if (errorStr.contains('expired')) {
+          _swapError = l10n.swapErrorExpired;
+        } else {
+          _swapError = l10n.swapErrorGeneric(e.toString());
+        }
+      });
+    }
+  }
+
+  /// Muestra modal de confirmación con desglose de fee.
+  void _showSwapConfirmation({
+    required MeltQuote meltQuote,
+    required Wallet srcWallet,
+    required Wallet destWallet,
+    required BigInt destAmount,
+  }) {
+    final l10n = L10n.of(context)!;
+    final srcUnitLabel = UnitFormatter.getUnitLabel(_srcUnit);
+    final destUnitLabel = UnitFormatter.getUnitLabel(_destUnit);
+    final total = meltQuote.amount + meltQuote.feeReserve;
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => Container(
+        padding: const EdgeInsets.all(AppDimensions.paddingMedium),
+        decoration: BoxDecoration(
+          color: AppColors.deepVoidPurple,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+          border: Border.all(
+            color: Colors.white.withValues(alpha: 0.1),
+            width: 1,
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Handle
+            Container(
+              margin: const EdgeInsets.only(bottom: 16),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+
+            // Icono swap
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                color: AppColors.primaryAction.withValues(alpha: 0.2),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                LucideIcons.arrowLeftRight,
+                color: AppColors.primaryAction,
+                size: 32,
+              ),
+            ),
+            const SizedBox(height: AppDimensions.paddingMedium),
+
+            // Título
+            Text(
+              l10n.confirmPayment,
+              style: const TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: AppDimensions.paddingSmall),
+
+            // Destino: lo que recibes
+            Text(
+              '+ ${UnitFormatter.formatBalance(destAmount, _destUnit)} $destUnitLabel',
+              style: const TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 28,
+                fontWeight: FontWeight.bold,
+                color: AppColors.success,
+              ),
+            ),
+            const SizedBox(height: 4),
+
+            // Origen: lo que pagas
+            Text(
+              '- ${UnitFormatter.formatBalance(meltQuote.amount, _srcUnit)} $srcUnitLabel',
+              style: const TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: Colors.white,
+              ),
+            ),
+
+            // Fee
+            Text(
+              '+ ~${UnitFormatter.formatBalance(meltQuote.feeReserve, _srcUnit)} $srcUnitLabel fee',
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 14,
+                color: AppColors.textSecondary.withValues(alpha: 0.7),
+              ),
+            ),
+            const SizedBox(height: AppDimensions.paddingSmall),
+
+            // Total
+            Text(
+              'Total: ${UnitFormatter.formatBalance(total, _srcUnit)} $srcUnitLabel',
+              style: const TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: AppColors.primaryAction,
+              ),
+            ),
+
+            const SizedBox(height: AppDimensions.paddingLarge),
+
+            // Botones
+            Row(
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.pop(ctx);
+                      _mintSubscription?.cancel();
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Center(
+                        child: Text(
+                          l10n.cancel,
+                          style: const TextStyle(
+                            fontFamily: 'Inter',
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppDimensions.paddingMedium),
+                Expanded(
+                  child: PrimaryButton(
+                    text: l10n.swapAction,
+                    onPressed: () {
+                      Navigator.pop(ctx);
+                      _executeSwap(
+                        meltQuote: meltQuote,
+                        srcWallet: srcWallet,
+                        destWallet: destWallet,
+                        destAmount: destAmount,
+                      );
+                    },
+                    height: 52,
+                  ),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: AppDimensions.paddingSmall),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Ejecuta el swap: melt en origen, guarda metadata de ambos lados.
+  Future<void> _executeSwap({
+    required MeltQuote meltQuote,
+    required Wallet srcWallet,
+    required Wallet destWallet,
+    required BigInt destAmount,
+  }) async {
+    final l10n = L10n.of(context)!;
+    final walletProvider = context.read<WalletProvider>();
+    final invoice = meltQuote.request;
+
+    setState(() {
+      _isSwapping = true;
+      _swapError = null;
+    });
+
+    try {
+      // Ejecutar melt (paga el invoice Lightning)
+      await srcWallet.melt(quote: meltQuote);
+
+      // Guardar metadata del melt (lado enviado)
+      await walletProvider.saveSwapMeltMetadata(
+        srcWallet, invoice, meltQuote.amount,
+      );
+
+      _mintSubscription?.cancel();
+
+      if (!mounted) return;
+
+      // Éxito: recargar balances, confetti, snackbar
+      await _loadBalances();
+      if (!mounted) return;
+
+      walletProvider.confettiController.fire();
+
+      // En background: esperar a que CDK procese el mint,
+      // guardar metadata del lado recibido y recargar balances
+      Future.delayed(const Duration(seconds: 3), () async {
+        await walletProvider.saveSwapMintMetadata(
+          destWallet, invoice, destAmount,
+        );
+        if (mounted) _loadBalances();
+      });
+
+      // Limpiar campos
+      _isUpdating = true;
+      _fromController.clear();
+      _toController.clear();
+      _isUpdating = false;
+
+      setState(() {
+        _isSwapping = false;
+        _swapError = null;
+      });
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.swapSuccess),
+          backgroundColor: AppColors.success,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      final errorStr = e.toString().toLowerCase();
+      setState(() {
+        _isSwapping = false;
+        if (errorStr.contains('insufficient') || errorStr.contains('not enough')) {
+          _swapError = l10n.swapErrorInsufficient;
+        } else if (errorStr.contains('expired')) {
+          _swapError = l10n.swapErrorExpired;
+        } else {
+          _swapError = l10n.swapErrorGeneric(e.toString());
+        }
+      });
+    } finally {
+      _mintSubscription?.cancel();
+      _mintSubscription = null;
     }
   }
 
@@ -188,35 +601,69 @@ class _SwapScreenState extends State<SwapScreen>
             l10n.swap,
             style: const TextStyle(
               fontFamily: 'Inter',
-              fontSize: 18,
               fontWeight: FontWeight.w600,
               color: Colors.white,
             ),
           ),
-          centerTitle: true,
         ),
         body: SafeArea(
-          child: SingleChildScrollView(
+          child: Padding(
             padding: const EdgeInsets.all(AppDimensions.paddingMedium),
             child: Column(
               children: [
+                // Precio + chart (arriba)
                 _buildPriceChart(priceProvider),
-                const SizedBox(height: AppDimensions.paddingMedium),
-                const SizedBox(height: AppDimensions.paddingLarge),
-                _buildFromCard(l10n),
-                _buildFlipButton(),
-                _buildToCard(l10n),
-                const SizedBox(height: AppDimensions.paddingMedium),
-                const SizedBox(height: AppDimensions.paddingLarge),
-                PrimaryButton(
-                  text: l10n.swapAction,
-                  onPressed: _amountController.text.isNotEmpty
-                      ? () {
-                          // TODO: implement swap logic
-                          HapticFeedback.heavyImpact();
-                        }
-                      : null,
+
+                // Cards De/A centradas verticalmente
+                Expanded(
+                  child: Center(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _buildFromCard(l10n),
+                          _buildFlipButton(),
+                          _buildToCard(l10n),
+                        ],
+                      ),
+                    ),
+                  ),
                 ),
+
+                // Validación + errores + botón fijo abajo
+                Builder(builder: (_) {
+                  final minError = _validateMinimums(l10n);
+                  final errorMsg = _swapError ?? minError;
+                  final canSwap = _fromController.text.isNotEmpty &&
+                      _toController.text.isNotEmpty &&
+                      minError == null &&
+                      !_isSwapping;
+
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (errorMsg != null)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: Text(
+                            errorMsg,
+                            style: const TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 12,
+                              color: AppColors.error,
+                            ),
+                          ),
+                        ),
+                      PrimaryButton(
+                        text: _isSwapping
+                            ? l10n.swapProcessing
+                            : l10n.swapAction,
+                        isLoading: _isSwapping,
+                        onPressed: canSwap ? _startSwap : null,
+                      ),
+                    ],
+                  );
+                }),
               ],
             ),
           ),
@@ -306,24 +753,26 @@ class _SwapScreenState extends State<SwapScreen>
     );
   }
 
-  Widget _buildFromCard(L10n l10n) {
-    final fromSymbol = _isSatsToUsd ? '₿' : '\$';
-    final fromLabel = _isSatsToUsd ? 'sats' : 'USD';
-    final fromBalance = _isSatsToUsd
-        ? UnitFormatter.formatBalance(_satsBalance, 'sat')
-        : UnitFormatter.formatBalance(_usdBalance, 'usd');
-    final fromUnit = _isSatsToUsd ? 'sat' : 'USD';
-
+  Widget _buildSwapCard({
+    required L10n l10n,
+    required String label,
+    required String symbol,
+    required String unitLabel,
+    required String balance,
+    required String unit,
+    required TextEditingController controller,
+    required bool isSats,
+    bool showUseAll = false,
+  }) {
     return GlassCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Label + Balance en la misma línea
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                l10n.swapFrom,
+                label,
                 style: TextStyle(
                   fontFamily: 'Inter',
                   fontSize: 12,
@@ -335,26 +784,28 @@ class _SwapScreenState extends State<SwapScreen>
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    '${l10n.balance}: $fromBalance $fromUnit',
+                    '${l10n.balance}: $balance $unit',
                     style: TextStyle(
                       fontFamily: 'Inter',
                       fontSize: 12,
                       color: AppColors.textSecondary.withValues(alpha: 0.6),
                     ),
                   ),
-                  const SizedBox(width: 6),
-                  GestureDetector(
-                    onTap: _setMaxAmount,
-                    child: Text(
-                      l10n.swapUseAll,
-                      style: const TextStyle(
-                        fontFamily: 'Inter',
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.primaryAction,
+                  if (showUseAll) ...[
+                    const SizedBox(width: 6),
+                    GestureDetector(
+                      onTap: _setMaxAmount,
+                      child: Text(
+                        l10n.swapUseAll,
+                        style: const TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.primaryAction,
+                        ),
                       ),
                     ),
-                  ),
+                  ],
                 ],
               ),
             ],
@@ -362,7 +813,6 @@ class _SwapScreenState extends State<SwapScreen>
           const SizedBox(height: 8),
           Row(
             children: [
-              // Unit pill
               Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -371,7 +821,7 @@ class _SwapScreenState extends State<SwapScreen>
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Text(
-                  '$fromSymbol $fromLabel',
+                  '$symbol $unitLabel',
                   style: const TextStyle(
                     fontFamily: 'Inter',
                     fontSize: 16,
@@ -381,13 +831,11 @@ class _SwapScreenState extends State<SwapScreen>
                 ),
               ),
               const SizedBox(width: 12),
-              // Amount input
               Expanded(
                 child: TextField(
-                  key: ValueKey('from_$_isSatsToUsd'),
-                  controller: _amountController,
+                  controller: controller,
                   keyboardType: TextInputType.numberWithOptions(
-                    decimal: !_isSatsToUsd,
+                    decimal: !isSats,
                   ),
                   style: const TextStyle(
                     fontFamily: 'Inter',
@@ -409,7 +857,7 @@ class _SwapScreenState extends State<SwapScreen>
                     isDense: true,
                   ),
                   inputFormatters: [
-                    if (_isSatsToUsd)
+                    if (isSats)
                       FilteringTextInputFormatter.digitsOnly
                     else
                       FilteringTextInputFormatter.allow(
@@ -462,6 +910,27 @@ class _SwapScreenState extends State<SwapScreen>
     );
   }
 
+  Widget _buildFromCard(L10n l10n) {
+    final fromSymbol = _isSatsToUsd ? '₿' : '\$';
+    final fromLabel = _isSatsToUsd ? 'sats' : 'USD';
+    final fromBalance = _isSatsToUsd
+        ? UnitFormatter.formatBalance(_satsBalance, 'sat')
+        : UnitFormatter.formatBalance(_usdBalance, 'usd');
+    final fromUnit = _isSatsToUsd ? 'sat' : 'USD';
+
+    return _buildSwapCard(
+      l10n: l10n,
+      label: l10n.swapFrom,
+      symbol: fromSymbol,
+      unitLabel: fromLabel,
+      balance: fromBalance,
+      unit: fromUnit,
+      controller: _fromController,
+      isSats: _isSatsToUsd,
+      showUseAll: true,
+    );
+  }
+
   Widget _buildToCard(L10n l10n) {
     final toSymbol = _isSatsToUsd ? '\$' : '₿';
     final toLabel = _isSatsToUsd ? 'USD' : 'sats';
@@ -470,70 +939,15 @@ class _SwapScreenState extends State<SwapScreen>
         : UnitFormatter.formatBalance(_satsBalance, 'sat');
     final toUnit = _isSatsToUsd ? 'USD' : 'sat';
 
-    return GlassCard(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Label + Balance en la misma línea
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                l10n.swapTo,
-                style: TextStyle(
-                  fontFamily: 'Inter',
-                  fontSize: 12,
-                  fontWeight: FontWeight.w500,
-                  color: AppColors.textSecondary.withValues(alpha: 0.6),
-                ),
-              ),
-              Text(
-                '${l10n.balance}: $toBalance $toUnit',
-                style: TextStyle(
-                  fontFamily: 'Inter',
-                  fontSize: 12,
-                  color: AppColors.textSecondary.withValues(alpha: 0.6),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Text(
-                  '$toSymbol $toLabel',
-                  style: const TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.white,
-                  ),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  _convertedAmount.isEmpty ? '≈ 0' : '≈ $_convertedAmount',
-                  textAlign: TextAlign.right,
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white.withValues(alpha: 0.7),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
+    return _buildSwapCard(
+      l10n: l10n,
+      label: l10n.swapTo,
+      symbol: toSymbol,
+      unitLabel: toLabel,
+      balance: toBalance,
+      unit: toUnit,
+      controller: _toController,
+      isSats: !_isSatsToUsd,
     );
   }
 

--- a/lib/screens/8_settings/settings_screen.dart
+++ b/lib/screens/8_settings/settings_screen.dart
@@ -15,6 +15,7 @@ import '../2_onboarding/backup_seed_screen.dart';
 import 'mints_screen.dart';
 import 'language_screen.dart';
 import 'p2pk_keys_screen.dart';
+import '../13_swap/swap_screen.dart';
 
 /// Pantalla de configuración
 class SettingsScreen extends StatefulWidget {
@@ -78,6 +79,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     _buildSectionHeader(l10n.walletSection),
                     const SizedBox(height: AppDimensions.paddingSmall),
                     _buildSettingTile(
+                      icon: LucideIcons.arrowLeftRight,
+                      title: l10n.swap,
+                      subtitle: l10n.swapDescription,
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const SwapScreen(),
+                          ),
+                        );
+                      },
+                    ),
+                    _buildSettingTile(
                       icon: LucideIcons.key,
                       title: l10n.backupSeedPhrase,
                       subtitle: l10n.viewRecoveryWords,
@@ -110,7 +124,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       ),
                     ),
                     _buildSettingTile(
-                      icon: LucideIcons.refreshCw,
+                      icon: LucideIcons.searchCode,
                       title: l10n.recoverTokens,
                       subtitle: l10n.scanMintsWithSeed,
                       onTap: () => _showRecoverTokensDialog(context, settingsProvider),


### PR DESCRIPTION
- New swap screen with sparkline chart from Blink API (btcPriceList)
- FROM/TO cards with flip animation and real-time conversion
- Balance display and 'Use all' option in FROM card                                                                                                   
- Added swap as first option in Settings > Wallet section
- Changed recover tokens icon to searchCode for clarity                                                                                               
- Translations for all 11 languages

This PR is UI only. The swap logic is not implemented yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap screen: sats↔USD UI with live conversion, flip direction, "use all", minimum validation, confirmation flow, execution, success feedback (confetti/snackbar) and sparkline price chart.
  * Historical BTC price fetching to power sparklines and conversion accuracy.

* **Chores**
  * Settings entry added to access Swap.
  * Wallet metadata saved for swap send/receive to improve transaction tracking.

* **Documentation**
  * Added swap localization strings across many languages (EN, DE, ES, FR, IT, JA, KO, PT, RU, SW, ZH).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->