### PR TITLE
feat: improve swap price chart — real data only, 24h stats, min/max

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "Swap abgeschlossen",
   "swapErrorInsufficient": "Unzureichendes Guthaben",
   "swapErrorExpired": "Angebot abgelaufen",
-  "swapErrorGeneric": "Swap-Fehler: {error}"
+  "swapErrorGeneric": "Swap-Fehler: {error}",
+  "swapChartUnavailable": "Preis nicht verfügbar · Tippen zum Wiederholen",
+  "swapChartMin": "Min",
+  "swapChartMax": "Max"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "Angebot abgelaufen",
   "swapErrorGeneric": "Swap-Fehler: {error}",
   "swapChartUnavailable": "Preis nicht verfügbar · Tippen zum Wiederholen",
-  "swapChartMin": "Min",
-  "swapChartMax": "Max"
+  "swapChartMinMax": "24h  Min: {minPrice} — Max: {maxPrice}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -468,6 +468,5 @@
   "swapErrorExpired": "Quote has expired",
   "swapErrorGeneric": "Swap error: {error}",
   "swapChartUnavailable": "Price unavailable · Tap to retry",
-  "swapChartMin": "Min",
-  "swapChartMax": "Max"
+  "swapChartMinMax": "24h  Min: {minPrice} — Max: {maxPrice}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -466,5 +466,8 @@
   "swapSuccess": "Swap completed",
   "swapErrorInsufficient": "Insufficient balance",
   "swapErrorExpired": "Quote has expired",
-  "swapErrorGeneric": "Swap error: {error}"
+  "swapErrorGeneric": "Swap error: {error}",
+  "swapChartUnavailable": "Price unavailable · Tap to retry",
+  "swapChartMin": "Min",
+  "swapChartMax": "Max"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -598,6 +598,11 @@
     }
   },
   "swapChartUnavailable": "Precio no disponible · Toca para reintentar",
-  "swapChartMin": "Mín",
-  "swapChartMax": "Máx"
+  "swapChartMinMax": "24h  Mín: {minPrice} — Máx: {maxPrice}",
+  "@swapChartMinMax": {
+    "placeholders": {
+      "minPrice": { "type": "String" },
+      "maxPrice": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -596,5 +596,8 @@
     "placeholders": {
       "error": { "type": "String" }
     }
-  }
+  },
+  "swapChartUnavailable": "Precio no disponible · Toca para reintentar",
+  "swapChartMin": "Mín",
+  "swapChartMax": "Máx"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "Le devis a expiré",
   "swapErrorGeneric": "Erreur de swap : {error}",
   "swapChartUnavailable": "Prix indisponible · Appuyez pour réessayer",
-  "swapChartMin": "Min",
-  "swapChartMax": "Max"
+  "swapChartMinMax": "24h  Min : {minPrice} — Max : {maxPrice}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "Swap terminé",
   "swapErrorInsufficient": "Solde insuffisant",
   "swapErrorExpired": "Le devis a expiré",
-  "swapErrorGeneric": "Erreur de swap : {error}"
+  "swapErrorGeneric": "Erreur de swap : {error}",
+  "swapChartUnavailable": "Prix indisponible · Appuyez pour réessayer",
+  "swapChartMin": "Min",
+  "swapChartMax": "Max"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "Il preventivo è scaduto",
   "swapErrorGeneric": "Errore swap: {error}",
   "swapChartUnavailable": "Prezzo non disponibile · Tocca per riprovare",
-  "swapChartMin": "Min",
-  "swapChartMax": "Max"
+  "swapChartMinMax": "24h  Min: {minPrice} — Max: {maxPrice}"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "Swap completato",
   "swapErrorInsufficient": "Saldo insufficiente",
   "swapErrorExpired": "Il preventivo è scaduto",
-  "swapErrorGeneric": "Errore swap: {error}"
+  "swapErrorGeneric": "Errore swap: {error}",
+  "swapChartUnavailable": "Prezzo non disponibile · Tocca per riprovare",
+  "swapChartMin": "Min",
+  "swapChartMax": "Max"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "スワップ完了",
   "swapErrorInsufficient": "残高不足",
   "swapErrorExpired": "見積もりの有効期限切れ",
-  "swapErrorGeneric": "スワップエラー: {error}"
+  "swapErrorGeneric": "スワップエラー: {error}",
+  "swapChartUnavailable": "価格を取得できません・タップで再試行",
+  "swapChartMin": "安値",
+  "swapChartMax": "高値"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "見積もりの有効期限切れ",
   "swapErrorGeneric": "スワップエラー: {error}",
   "swapChartUnavailable": "価格を取得できません・タップで再試行",
-  "swapChartMin": "安値",
-  "swapChartMax": "高値"
+  "swapChartMinMax": "24h  安値: {minPrice} — 高値: {maxPrice}"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "교환 완료",
   "swapErrorInsufficient": "잔액 부족",
   "swapErrorExpired": "견적이 만료되었습니다",
-  "swapErrorGeneric": "교환 오류: {error}"
+  "swapErrorGeneric": "교환 오류: {error}",
+  "swapChartUnavailable": "가격 불러오기 실패 · 탭하여 재시도",
+  "swapChartMin": "최저",
+  "swapChartMax": "최고"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "견적이 만료되었습니다",
   "swapErrorGeneric": "교환 오류: {error}",
   "swapChartUnavailable": "가격 불러오기 실패 · 탭하여 재시도",
-  "swapChartMin": "최저",
-  "swapChartMax": "최고"
+  "swapChartMinMax": "24h  최저: {minPrice} — 최고: {maxPrice}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2430,6 +2430,24 @@ abstract class L10n {
   /// In es, this message translates to:
   /// **'Error en el swap: {error}'**
   String swapErrorGeneric(String error);
+
+  /// No description provided for @swapChartUnavailable.
+  ///
+  /// In es, this message translates to:
+  /// **'Precio no disponible · Toca para reintentar'**
+  String get swapChartUnavailable;
+
+  /// No description provided for @swapChartMin.
+  ///
+  /// In es, this message translates to:
+  /// **'Mín'**
+  String get swapChartMin;
+
+  /// No description provided for @swapChartMax.
+  ///
+  /// In es, this message translates to:
+  /// **'Máx'**
+  String get swapChartMax;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2437,17 +2437,11 @@ abstract class L10n {
   /// **'Precio no disponible · Toca para reintentar'**
   String get swapChartUnavailable;
 
-  /// No description provided for @swapChartMin.
+  /// No description provided for @swapChartMinMax.
   ///
   /// In es, this message translates to:
-  /// **'Mín'**
-  String get swapChartMin;
-
-  /// No description provided for @swapChartMax.
-  ///
-  /// In es, this message translates to:
-  /// **'Máx'**
-  String get swapChartMax;
+  /// **'24h  Mín: {minPrice} — Máx: {maxPrice}'**
+  String swapChartMinMax(String minPrice, String maxPrice);
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1290,8 +1290,7 @@ class L10nDe extends L10n {
       'Preis nicht verfügbar · Tippen zum Wiederholen';
 
   @override
-  String get swapChartMin => 'Min';
-
-  @override
-  String get swapChartMax => 'Max';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Min: $minPrice — Max: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1284,4 +1284,14 @@ class L10nDe extends L10n {
   String swapErrorGeneric(String error) {
     return 'Swap-Fehler: $error';
   }
+
+  @override
+  String get swapChartUnavailable =>
+      'Preis nicht verfügbar · Tippen zum Wiederholen';
+
+  @override
+  String get swapChartMin => 'Min';
+
+  @override
+  String get swapChartMax => 'Max';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1270,8 +1270,7 @@ class L10nEn extends L10n {
   String get swapChartUnavailable => 'Price unavailable · Tap to retry';
 
   @override
-  String get swapChartMin => 'Min';
-
-  @override
-  String get swapChartMax => 'Max';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Min: $minPrice — Max: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1265,4 +1265,13 @@ class L10nEn extends L10n {
   String swapErrorGeneric(String error) {
     return 'Swap error: $error';
   }
+
+  @override
+  String get swapChartUnavailable => 'Price unavailable · Tap to retry';
+
+  @override
+  String get swapChartMin => 'Min';
+
+  @override
+  String get swapChartMax => 'Max';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1279,8 +1279,7 @@ class L10nEs extends L10n {
       'Precio no disponible · Toca para reintentar';
 
   @override
-  String get swapChartMin => 'Mín';
-
-  @override
-  String get swapChartMax => 'Máx';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Mín: $minPrice — Máx: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1273,4 +1273,14 @@ class L10nEs extends L10n {
   String swapErrorGeneric(String error) {
     return 'Error en el swap: $error';
   }
+
+  @override
+  String get swapChartUnavailable =>
+      'Precio no disponible · Toca para reintentar';
+
+  @override
+  String get swapChartMin => 'Mín';
+
+  @override
+  String get swapChartMax => 'Máx';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1295,8 +1295,7 @@ class L10nFr extends L10n {
       'Prix indisponible · Appuyez pour réessayer';
 
   @override
-  String get swapChartMin => 'Min';
-
-  @override
-  String get swapChartMax => 'Max';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Min : $minPrice — Max : $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1289,4 +1289,14 @@ class L10nFr extends L10n {
   String swapErrorGeneric(String error) {
     return 'Erreur de swap : $error';
   }
+
+  @override
+  String get swapChartUnavailable =>
+      'Prix indisponible · Appuyez pour réessayer';
+
+  @override
+  String get swapChartMin => 'Min';
+
+  @override
+  String get swapChartMax => 'Max';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1277,4 +1277,14 @@ class L10nIt extends L10n {
   String swapErrorGeneric(String error) {
     return 'Errore swap: $error';
   }
+
+  @override
+  String get swapChartUnavailable =>
+      'Prezzo non disponibile · Tocca per riprovare';
+
+  @override
+  String get swapChartMin => 'Min';
+
+  @override
+  String get swapChartMax => 'Max';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1283,8 +1283,7 @@ class L10nIt extends L10n {
       'Prezzo non disponibile · Tocca per riprovare';
 
   @override
-  String get swapChartMin => 'Min';
-
-  @override
-  String get swapChartMax => 'Max';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Min: $minPrice — Max: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1250,4 +1250,13 @@ class L10nJa extends L10n {
   String swapErrorGeneric(String error) {
     return 'スワップエラー: $error';
   }
+
+  @override
+  String get swapChartUnavailable => '価格を取得できません・タップで再試行';
+
+  @override
+  String get swapChartMin => '安値';
+
+  @override
+  String get swapChartMax => '高値';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1255,8 +1255,7 @@ class L10nJa extends L10n {
   String get swapChartUnavailable => '価格を取得できません・タップで再試行';
 
   @override
-  String get swapChartMin => '安値';
-
-  @override
-  String get swapChartMax => '高値';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  安値: $minPrice — 高値: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1257,8 +1257,7 @@ class L10nKo extends L10n {
   String get swapChartUnavailable => '가격 불러오기 실패 · 탭하여 재시도';
 
   @override
-  String get swapChartMin => '최저';
-
-  @override
-  String get swapChartMax => '최고';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  최저: $minPrice — 최고: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1252,4 +1252,13 @@ class L10nKo extends L10n {
   String swapErrorGeneric(String error) {
     return '교환 오류: $error';
   }
+
+  @override
+  String get swapChartUnavailable => '가격 불러오기 실패 · 탭하여 재시도';
+
+  @override
+  String get swapChartMin => '최저';
+
+  @override
+  String get swapChartMax => '최고';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1283,8 +1283,7 @@ class L10nPt extends L10n {
       'Preço indisponível · Toque para tentar novamente';
 
   @override
-  String get swapChartMin => 'Mín';
-
-  @override
-  String get swapChartMax => 'Máx';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Mín: $minPrice — Máx: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1277,4 +1277,14 @@ class L10nPt extends L10n {
   String swapErrorGeneric(String error) {
     return 'Erro no swap: $error';
   }
+
+  @override
+  String get swapChartUnavailable =>
+      'Preço indisponível · Toque para tentar novamente';
+
+  @override
+  String get swapChartMin => 'Mín';
+
+  @override
+  String get swapChartMax => 'Máx';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1273,4 +1273,13 @@ class L10nRu extends L10n {
   String swapErrorGeneric(String error) {
     return 'Ошибка обмена: $error';
   }
+
+  @override
+  String get swapChartUnavailable => 'Цена недоступна · Нажмите для повтора';
+
+  @override
+  String get swapChartMin => 'Мин';
+
+  @override
+  String get swapChartMax => 'Макс';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1278,8 +1278,7 @@ class L10nRu extends L10n {
   String get swapChartUnavailable => 'Цена недоступна · Нажмите для повтора';
 
   @override
-  String get swapChartMin => 'Мин';
-
-  @override
-  String get swapChartMax => 'Макс';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Мин: $minPrice — Макс: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1274,4 +1274,13 @@ class L10nSw extends L10n {
   String swapErrorGeneric(String error) {
     return 'Kosa la ubadilishaji: $error';
   }
+
+  @override
+  String get swapChartUnavailable => 'Bei haipatikani · Gusa kurudia';
+
+  @override
+  String get swapChartMin => 'Chini';
+
+  @override
+  String get swapChartMax => 'Juu';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1279,8 +1279,7 @@ class L10nSw extends L10n {
   String get swapChartUnavailable => 'Bei haipatikani · Gusa kurudia';
 
   @override
-  String get swapChartMin => 'Chini';
-
-  @override
-  String get swapChartMax => 'Juu';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  Chini: $minPrice — Juu: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1250,8 +1250,7 @@ class L10nZh extends L10n {
   String get swapChartUnavailable => '价格不可用 · 点击重试';
 
   @override
-  String get swapChartMin => '最低';
-
-  @override
-  String get swapChartMax => '最高';
+  String swapChartMinMax(String minPrice, String maxPrice) {
+    return '24h  最低: $minPrice — 最高: $maxPrice';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1245,4 +1245,13 @@ class L10nZh extends L10n {
   String swapErrorGeneric(String error) {
     return '兑换错误: $error';
   }
+
+  @override
+  String get swapChartUnavailable => '价格不可用 · 点击重试';
+
+  @override
+  String get swapChartMin => '最低';
+
+  @override
+  String get swapChartMax => '最高';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "Swap concluído",
   "swapErrorInsufficient": "Saldo insuficiente",
   "swapErrorExpired": "A cotação expirou",
-  "swapErrorGeneric": "Erro no swap: {error}"
+  "swapErrorGeneric": "Erro no swap: {error}",
+  "swapChartUnavailable": "Preço indisponível · Toque para tentar novamente",
+  "swapChartMin": "Mín",
+  "swapChartMax": "Máx"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "A cotação expirou",
   "swapErrorGeneric": "Erro no swap: {error}",
   "swapChartUnavailable": "Preço indisponível · Toque para tentar novamente",
-  "swapChartMin": "Mín",
-  "swapChartMax": "Máx"
+  "swapChartMinMax": "24h  Mín: {minPrice} — Máx: {maxPrice}"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "Обмен завершён",
   "swapErrorInsufficient": "Недостаточный баланс",
   "swapErrorExpired": "Котировка истекла",
-  "swapErrorGeneric": "Ошибка обмена: {error}"
+  "swapErrorGeneric": "Ошибка обмена: {error}",
+  "swapChartUnavailable": "Цена недоступна · Нажмите для повтора",
+  "swapChartMin": "Мин",
+  "swapChartMax": "Макс"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "Котировка истекла",
   "swapErrorGeneric": "Ошибка обмена: {error}",
   "swapChartUnavailable": "Цена недоступна · Нажмите для повтора",
-  "swapChartMin": "Мин",
-  "swapChartMax": "Макс"
+  "swapChartMinMax": "24h  Мин: {minPrice} — Макс: {maxPrice}"
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "Bei imeisha muda",
   "swapErrorGeneric": "Kosa la ubadilishaji: {error}",
   "swapChartUnavailable": "Bei haipatikani · Gusa kurudia",
-  "swapChartMin": "Chini",
-  "swapChartMax": "Juu"
+  "swapChartMinMax": "24h  Chini: {minPrice} — Juu: {maxPrice}"
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "Ubadilishaji umekamilika",
   "swapErrorInsufficient": "Salio haitoshi",
   "swapErrorExpired": "Bei imeisha muda",
-  "swapErrorGeneric": "Kosa la ubadilishaji: {error}"
+  "swapErrorGeneric": "Kosa la ubadilishaji: {error}",
+  "swapChartUnavailable": "Bei haipatikani · Gusa kurudia",
+  "swapChartMin": "Chini",
+  "swapChartMax": "Juu"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -575,6 +575,5 @@
   "swapErrorExpired": "报价已过期",
   "swapErrorGeneric": "兑换错误: {error}",
   "swapChartUnavailable": "价格不可用 · 点击重试",
-  "swapChartMin": "最低",
-  "swapChartMax": "最高"
+  "swapChartMinMax": "24h  最低: {minPrice} — 最高: {maxPrice}"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -573,5 +573,8 @@
   "swapSuccess": "兑换完成",
   "swapErrorInsufficient": "余额不足",
   "swapErrorExpired": "报价已过期",
-  "swapErrorGeneric": "兑换错误: {error}"
+  "swapErrorGeneric": "兑换错误: {error}",
+  "swapChartUnavailable": "价格不可用 · 点击重试",
+  "swapChartMin": "最低",
+  "swapChartMax": "最高"
 }

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -103,9 +103,13 @@ class _SwapScreenState extends State<SwapScreen>
     try {
       final prices = await PriceService.getHistoricalPrices(range: 'ONE_DAY');
       if (!mounted) return;
-      if (prices.length >= 2) {
+      final chartData = prices
+          .map((p) => p.priceUsd)
+          .where((price) => price.isFinite && price > 0)
+          .toList();
+      if (chartData.length >= 2) {
         setState(() {
-          _chartData = prices.map((p) => p.priceUsd).toList();
+          _chartData = chartData;
           _isLoadingChart = false;
         });
       } else {

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -44,6 +44,7 @@ class _SwapScreenState extends State<SwapScreen>
 
   List<double> _chartData = [];
   bool _isLoadingChart = true;
+  bool _chartError = false;
 
   // --- Swap state ---
   bool _isSwapping = false;
@@ -81,7 +82,6 @@ class _SwapScreenState extends State<SwapScreen>
   Future<void> _loadBalances() async {
     final walletProvider = context.read<WalletProvider>();
     final mintUrl = WalletProvider.cubaBitcoinMint;
-    if (mintUrl == null) return;
 
     try {
       final balances = await walletProvider.getBalancesForMint(mintUrl);
@@ -96,6 +96,10 @@ class _SwapScreenState extends State<SwapScreen>
   }
 
   Future<void> _loadChartData() async {
+    setState(() {
+      _isLoadingChart = true;
+      _chartError = false;
+    });
     try {
       final prices = await PriceService.getHistoricalPrices(range: 'ONE_DAY');
       if (mounted && prices.isNotEmpty) {
@@ -107,20 +111,12 @@ class _SwapScreenState extends State<SwapScreen>
     } catch (_) {
       if (mounted) {
         setState(() {
-          _chartData = _generateMockData();
+          _chartData = [];
           _isLoadingChart = false;
+          _chartError = true;
         });
       }
     }
-  }
-
-  List<double> _generateMockData() {
-    final priceProvider = context.read<PriceProvider>();
-    final basePrice = priceProvider.btcPriceUsd ?? 65000;
-    final rng = Random();
-    return List.generate(24, (i) {
-      return basePrice + (rng.nextDouble() - 0.48) * basePrice * 0.02;
-    });
   }
 
   void _onFromChanged() {
@@ -263,7 +259,6 @@ class _SwapScreenState extends State<SwapScreen>
   Future<void> _startSwap() async {
     final walletProvider = context.read<WalletProvider>();
     final mintUrl = WalletProvider.cubaBitcoinMint;
-    if (mintUrl == null) return;
 
     final destAmount = _getDestAmount();
     if (destAmount <= BigInt.zero) return;
@@ -708,24 +703,42 @@ class _SwapScreenState extends State<SwapScreen>
   // --- Widgets ---
 
   Widget _buildPriceChart(PriceProvider priceProvider) {
+    final l10n = L10n.of(context)!;
     final btcPrice = priceProvider.btcPriceUsd;
-    final priceStr = btcPrice != null
-        ? '\$${NumberFormat('#,###').format(btcPrice.round())}'
-        : '...';
+    final fmt = NumberFormat('#,###');
+    final priceStr = btcPrice != null ? '\$${fmt.format(btcPrice.round())}' : '...';
 
     String rateStr = '...';
     if (btcPrice != null && btcPrice > 0) {
       final satsPerDollar = (100000000 / btcPrice).round();
-      rateStr = '1 USD ≈ ${NumberFormat('#,###').format(satsPerDollar)} sats';
+      rateStr = '1 USD ≈ ${fmt.format(satsPerDollar)} sats';
     }
 
-    final isUpTrend =
-        _chartData.length >= 2 && _chartData.last >= _chartData.first;
+    final hasData = _chartData.length >= 2;
+    final isUpTrend = hasData && _chartData.last >= _chartData.first;
     final trendColor = isUpTrend ? AppColors.success : AppColors.error;
+
+    // % cambio 24h
+    String? changeStr;
+    if (hasData) {
+      final change = ((_chartData.last - _chartData.first) / _chartData.first) * 100;
+      final sign = change >= 0 ? '+' : '';
+      changeStr = '$sign${change.toStringAsFixed(1)}% 24h';
+    }
+
+    // Min/Max 24h
+    String? minMaxStr;
+    if (hasData) {
+      final minVal = _chartData.reduce(min);
+      final maxVal = _chartData.reduce(max);
+      final minLabel = l10n.swapChartMin;
+      final maxLabel = l10n.swapChartMax;
+      minMaxStr = '24h  $minLabel: \$${fmt.format(minVal.round())} — $maxLabel: \$${fmt.format(maxVal.round())}';
+    }
 
     return Column(
       children: [
-        // Price
+        // Precio centrado
         Text(
           priceStr,
           style: const TextStyle(
@@ -736,18 +749,35 @@ class _SwapScreenState extends State<SwapScreen>
           ),
         ),
         const SizedBox(height: 2),
-        Text(
-          'USD',
-          style: TextStyle(
-            fontFamily: 'Inter',
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            color: AppColors.textSecondary.withValues(alpha: 0.6),
-          ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'BTC/USD',
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: AppColors.textSecondary.withValues(alpha: 0.6),
+              ),
+            ),
+            if (changeStr != null) ...[
+              const SizedBox(width: 8),
+              Text(
+                changeStr,
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: trendColor,
+                ),
+              ),
+            ],
+          ],
         ),
         const SizedBox(height: 8),
 
-        // Sparkline (sin contenedor, integrado)
+        // Sparkline o estado de error
         SizedBox(
           height: 40,
           width: double.infinity,
@@ -762,15 +792,44 @@ class _SwapScreenState extends State<SwapScreen>
                     ),
                   ),
                 )
-              : CustomPaint(
-                  painter: _SparklinePainter(
-                    data: _chartData,
-                    lineColor: trendColor,
-                    fillColor: trendColor.withValues(alpha: 0.08),
-                  ),
-                ),
+              : _chartError
+                  ? GestureDetector(
+                      onTap: _loadChartData,
+                      child: Center(
+                        child: Text(
+                          l10n.swapChartUnavailable,
+                          style: TextStyle(
+                            fontFamily: 'Inter',
+                            fontSize: 12,
+                            color: AppColors.textSecondary.withValues(alpha: 0.5),
+                          ),
+                        ),
+                      ),
+                    )
+                  : CustomPaint(
+                      painter: _SparklinePainter(
+                        data: _chartData,
+                        lineColor: trendColor,
+                        fillColor: trendColor.withValues(alpha: 0.08),
+                      ),
+                    ),
         ),
         const SizedBox(height: 8),
+
+        // Min/Max 24h
+        if (minMaxStr != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Text(
+              minMaxStr,
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: AppColors.textSecondary.withValues(alpha: 0.5),
+              ),
+            ),
+          ),
 
         // Exchange rate
         Text(

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -102,10 +102,17 @@ class _SwapScreenState extends State<SwapScreen>
     });
     try {
       final prices = await PriceService.getHistoricalPrices(range: 'ONE_DAY');
-      if (mounted && prices.isNotEmpty) {
+      if (!mounted) return;
+      if (prices.length >= 2) {
         setState(() {
           _chartData = prices.map((p) => p.priceUsd).toList();
           _isLoadingChart = false;
+        });
+      } else {
+        setState(() {
+          _chartData = [];
+          _isLoadingChart = false;
+          _chartError = true;
         });
       }
     } catch (_) {
@@ -731,9 +738,10 @@ class _SwapScreenState extends State<SwapScreen>
     if (hasData) {
       final minVal = _chartData.reduce(min);
       final maxVal = _chartData.reduce(max);
-      final minLabel = l10n.swapChartMin;
-      final maxLabel = l10n.swapChartMax;
-      minMaxStr = '24h  $minLabel: \$${fmt.format(minVal.round())} — $maxLabel: \$${fmt.format(maxVal.round())}';
+      minMaxStr = l10n.swapChartMinMax(
+        '\$${fmt.format(minVal.round())}',
+        '\$${fmt.format(maxVal.round())}',
+      );
     }
 
     return Column(


### PR DESCRIPTION
- Remove mock data generation on API failure, show retry message instead
- Add 24h percentage change next to BTC/USD label
- Add 24h Min/Max prices below sparkline
- Remove dead code (null checks on non-nullable cubaBitcoinMint)
- Add i18n keys (swapChartUnavailable, swapChartMin, swapChartMax) in 11 languages"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Swap price chart shows 24h Min/Max labels and BTC/USD subtitle.
  - Tap-to-retry "Price unavailable · Tap to retry" state for the chart.

* **Improvements**
  - Clearer handling and feedback when swap chart data fails.
  - New localized text for the swap chart UI added across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->