### PR TITLE
fix: recover reserved proofs on melt failure and validate minimum viable amounts

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -118,6 +118,7 @@
   "confirm": "Bestätigen",
   "cancel": "Abbrechen",
   "insufficientBalance": "Unzureichendes Guthaben",
+  "feeExceedsAmount": "Die Gebühr übersteigt den Sendebetrag",
   "tokenCreationError": "Fehler beim Erstellen des Tokens: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -103,6 +103,7 @@
   "confirm": "Confirm",
   "cancel": "Cancel",
   "insufficientBalance": "Insufficient balance",
+  "feeExceedsAmount": "Fee exceeds the amount to send",
   "tokenCreationError": "Error creating token: {error}",
 
   "tokenCreated": "Token created",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -118,6 +118,7 @@
   "confirm": "Confirmar",
   "cancel": "Cancelar",
   "insufficientBalance": "Balance insuficiente",
+  "feeExceedsAmount": "La comisión supera el monto a enviar",
   "tokenCreationError": "Error al crear token: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -118,6 +118,7 @@
   "confirm": "Confirmer",
   "cancel": "Annuler",
   "insufficientBalance": "Solde insuffisant",
+  "feeExceedsAmount": "Les frais dépassent le montant à envoyer",
   "tokenCreationError": "Erreur de création du token : {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -118,6 +118,7 @@
   "confirm": "Conferma",
   "cancel": "Annulla",
   "insufficientBalance": "Saldo insufficiente",
+  "feeExceedsAmount": "La commissione supera l'importo da inviare",
   "tokenCreationError": "Errore creazione token: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -118,6 +118,7 @@
   "confirm": "確認",
   "cancel": "キャンセル",
   "insufficientBalance": "残高不足",
+  "feeExceedsAmount": "手数料が送金額を超えています",
   "tokenCreationError": "トークン作成エラー：{error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -118,6 +118,7 @@
   "confirm": "확인",
   "cancel": "취소",
   "insufficientBalance": "잔액 부족",
+  "feeExceedsAmount": "수수료가 송금액을 초과합니다",
   "tokenCreationError": "토큰 생성 오류: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -661,6 +661,12 @@ abstract class L10n {
   /// **'Balance insuficiente'**
   String get insufficientBalance;
 
+  /// No description provided for @feeExceedsAmount.
+  ///
+  /// In es, this message translates to:
+  /// **'La comisión supera el monto a enviar'**
+  String get feeExceedsAmount;
+
   /// No description provided for @tokenCreationError.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -296,6 +296,9 @@ class L10nDe extends L10n {
   String get insufficientBalance => 'Unzureichendes Guthaben';
 
   @override
+  String get feeExceedsAmount => 'Die Gebühr übersteigt den Sendebetrag';
+
+  @override
   String tokenCreationError(String error) {
     return 'Fehler beim Erstellen des Tokens: $error';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -293,6 +293,9 @@ class L10nEn extends L10n {
   String get insufficientBalance => 'Insufficient balance';
 
   @override
+  String get feeExceedsAmount => 'Fee exceeds the amount to send';
+
+  @override
   String tokenCreationError(String error) {
     return 'Error creating token: $error';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -293,6 +293,9 @@ class L10nEs extends L10n {
   String get insufficientBalance => 'Balance insuficiente';
 
   @override
+  String get feeExceedsAmount => 'La comisión supera el monto a enviar';
+
+  @override
   String tokenCreationError(String error) {
     return 'Error al crear token: $error';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -297,6 +297,9 @@ class L10nFr extends L10n {
   String get insufficientBalance => 'Solde insuffisant';
 
   @override
+  String get feeExceedsAmount => 'Les frais dépassent le montant à envoyer';
+
+  @override
   String tokenCreationError(String error) {
     return 'Erreur de création du token : $error';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -294,6 +294,9 @@ class L10nIt extends L10n {
   String get insufficientBalance => 'Saldo insufficiente';
 
   @override
+  String get feeExceedsAmount => 'La commissione supera l\'importo da inviare';
+
+  @override
   String tokenCreationError(String error) {
     return 'Errore creazione token: $error';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -289,6 +289,9 @@ class L10nJa extends L10n {
   String get insufficientBalance => '残高不足';
 
   @override
+  String get feeExceedsAmount => '手数料が送金額を超えています';
+
+  @override
   String tokenCreationError(String error) {
     return 'トークン作成エラー：$error';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -291,6 +291,9 @@ class L10nKo extends L10n {
   String get insufficientBalance => '잔액 부족';
 
   @override
+  String get feeExceedsAmount => '수수료가 송금액을 초과합니다';
+
+  @override
   String tokenCreationError(String error) {
     return '토큰 생성 오류: $error';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -294,6 +294,9 @@ class L10nPt extends L10n {
   String get insufficientBalance => 'Saldo insuficiente';
 
   @override
+  String get feeExceedsAmount => 'A taxa excede o valor a enviar';
+
+  @override
   String tokenCreationError(String error) {
     return 'Erro ao criar token: $error';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -293,6 +293,9 @@ class L10nRu extends L10n {
   String get insufficientBalance => 'Недостаточный баланс';
 
   @override
+  String get feeExceedsAmount => 'Комиссия превышает сумму отправки';
+
+  @override
   String tokenCreationError(String error) {
     return 'Ошибка создания токена: $error';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -294,6 +294,9 @@ class L10nSw extends L10n {
   String get insufficientBalance => 'Salio halitoshi';
 
   @override
+  String get feeExceedsAmount => 'Ada inazidi kiasi cha kutuma';
+
+  @override
   String tokenCreationError(String error) {
     return 'Hitilafu ya kuunda tokeni: $error';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -288,6 +288,9 @@ class L10nZh extends L10n {
   String get insufficientBalance => '余额不足';
 
   @override
+  String get feeExceedsAmount => '手续费超过发送金额';
+
+  @override
   String tokenCreationError(String error) {
     return '创建代币错误：$error';
   }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -118,6 +118,7 @@
   "confirm": "Confirmar",
   "cancel": "Cancelar",
   "insufficientBalance": "Saldo insuficiente",
+  "feeExceedsAmount": "A taxa excede o valor a enviar",
   "tokenCreationError": "Erro ao criar token: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -118,6 +118,7 @@
   "confirm": "Подтвердить",
   "cancel": "Отмена",
   "insufficientBalance": "Недостаточный баланс",
+  "feeExceedsAmount": "Комиссия превышает сумму отправки",
   "tokenCreationError": "Ошибка создания токена: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -118,6 +118,7 @@
   "confirm": "Thibitisha",
   "cancel": "Ghairi",
   "insufficientBalance": "Salio halitoshi",
+  "feeExceedsAmount": "Ada inazidi kiasi cha kutuma",
   "tokenCreationError": "Hitilafu ya kuunda tokeni: {error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -118,6 +118,7 @@
   "confirm": "确认",
   "cancel": "取消",
   "insufficientBalance": "余额不足",
+  "feeExceedsAmount": "手续费超过发送金额",
   "tokenCreationError": "创建代币错误：{error}",
   "@tokenCreationError": {
     "placeholders": {

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1498,19 +1498,57 @@ class WalletProvider extends ChangeNotifier {
   }
 
   /// Ejecuta el pago del invoice.
-  /// Guarda metadata type=lightning para identificar en historial.
+  /// Usa prepare/confirm/cancel para recuperar proofs si el pago falla.
   Future<BigInt> melt(MeltQuote quote) async {
     final wallet = await getActiveWallet();
-    final totalPaid = await wallet.melt(quote: quote);
+    final prepared = await wallet.prepareMelt(quote: quote);
+    try {
+      final totalPaid = await wallet.confirmMelt(melt: prepared);
 
-    // Guardar metadata con el invoice
-    if (_pendingMeltInvoice != null) {
-      await _saveMeltMetadata(wallet, _pendingMeltInvoice!);
-      _pendingMeltInvoice = null;
+      // Guardar metadata con el invoice
+      if (_pendingMeltInvoice != null) {
+        await _saveMeltMetadata(wallet, _pendingMeltInvoice!);
+        _pendingMeltInvoice = null;
+      }
+
+      notifyListeners();
+      return totalPaid;
+    } catch (e) {
+      try {
+        await wallet.cancelMelt(melt: prepared);
+      } catch (cancelErr) {
+        debugPrint('[MELT] cancelMelt failed: $cancelErr');
+      }
+      rethrow;
     }
+  }
 
-    notifyListeners();
-    return totalPaid;
+  /// Recupera proofs huérfanas en PendingSpent consultando el mint.
+  /// Solo revierte proofs que el mint confirma como no gastadas.
+  /// Si [mintUrl] es null, escanea todos los mints.
+  /// Retorna {count, amount} total de proofs recuperadas.
+  Future<ReclaimResult> reclaimPendingProofs({String? mintUrl}) async {
+    var totalCount = BigInt.zero;
+    var totalAmount = BigInt.zero;
+    final mints = mintUrl != null
+        ? {mintUrl: _mintUnits[mintUrl] ?? ['sat']}
+        : _mintUnits;
+    for (final entry in mints.entries) {
+      for (final unit in entry.value) {
+        try {
+          final wallet = await getWallet(entry.key, unit);
+          final result = await wallet.reclaimPendingProofs();
+          totalCount += result.count;
+          totalAmount += result.amount;
+        } catch (e) {
+          debugPrint('Reclaim pending proofs failed for ${entry.key}:$unit: $e');
+        }
+      }
+    }
+    if (totalCount > BigInt.zero) {
+      notifyListeners();
+    }
+    return ReclaimResult(count: totalCount, amount: totalAmount);
   }
 
   /// Guarda metadata para una transacción de melt (Lightning withdrawal).
@@ -1694,6 +1732,7 @@ class WalletProvider extends ChangeNotifier {
             // Silencioso - puede fallar offline
             debugPrint('Check pending failed: $e');
           }
+
         } catch (e) {
           debugPrint('Error getting wallet ${entry.key}:$unit: $e');
         }

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -550,6 +550,15 @@ class _SwapScreenState extends State<SwapScreen>
       _swapError = null;
     });
 
+    // Verificar que el fee no supere el monto (operación inviable)
+    if (meltQuote.amount <= meltQuote.feeReserve) {
+      setState(() {
+        _isSwapping = false;
+        _swapError = l10n.feeExceedsAmount;
+      });
+      return;
+    }
+
     late final PreparedMelt prepared;
     try {
       prepared = await srcWallet.prepareMelt(quote: meltQuote);
@@ -609,7 +618,9 @@ class _SwapScreenState extends State<SwapScreen>
       // Liberar solo las proofs reservadas para ESTE melt
       try {
         await srcWallet.cancelMelt(melt: prepared);
-      } catch (_) {}
+      } catch (cancelErr) {
+        debugPrint('[SWAP] cancelMelt failed: $cancelErr');
+      }
 
       if (!mounted) return;
       final errorStr = e.toString().toLowerCase();

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -550,9 +550,22 @@ class _SwapScreenState extends State<SwapScreen>
       _swapError = null;
     });
 
+    late final PreparedMelt prepared;
+    try {
+      prepared = await srcWallet.prepareMelt(quote: meltQuote);
+    } catch (e) {
+      // prepareMelt falló: no hay proofs reservadas, solo mostrar error
+      if (!mounted) return;
+      setState(() {
+        _isSwapping = false;
+        _swapError = l10n.swapErrorGeneric(e.toString());
+      });
+      return;
+    }
+
     try {
       // Ejecutar melt (paga el invoice Lightning)
-      await srcWallet.melt(quote: meltQuote);
+      await srcWallet.confirmMelt(melt: prepared);
 
       // Guardar metadata del melt (lado enviado)
       await walletProvider.saveSwapMeltMetadata(
@@ -592,6 +605,12 @@ class _SwapScreenState extends State<SwapScreen>
     } catch (e) {
       _mintSubscription?.cancel();
       _mintSubscription = null;
+
+      // Liberar solo las proofs reservadas para ESTE melt
+      try {
+        await srcWallet.cancelMelt(melt: prepared);
+      } catch (_) {}
+
       if (!mounted) return;
       final errorStr = e.toString().toLowerCase();
       setState(() {

--- a/lib/screens/5_send/offline_send_screen.dart
+++ b/lib/screens/5_send/offline_send_screen.dart
@@ -11,6 +11,7 @@ import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/common/primary_button.dart';
 import '../../widgets/proof/proof_selector.dart';
+import '../../core/utils/keyset_debug.dart';
 import 'share_token_screen.dart';
 
 /// Pantalla para enviar tokens de forma offline seleccionando proofs manualmente.
@@ -325,6 +326,21 @@ class _OfflineSendScreenState extends State<OfflineSendScreen> {
   Future<void> _createOfflineToken() async {
     final selectedProofs = _selectedProofs;
     final selectedTotal = _proofService.calculateTotal(selectedProofs);
+
+    // Validar monto mínimo viable para el receptor
+    // Leer ppk del keyset local, fallback a 100 (estándar)
+    var ppk = await KeysetDebug.getInputFeePpk(widget.mintUrl, widget.unit);
+    if (ppk < 0) ppk = 100; // -1 = error leyendo DB, asumir fee estándar
+    final minReceiveFee = ppk > 0 ? BigInt.from((ppk + 999) ~/ 1000) : BigInt.zero;
+    if (selectedTotal <= minReceiveFee) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = L10n.of(context)!.feeExceedsAmount;
+        });
+      }
+      return;
+    }
+
     var proofsMarkedPending = false;
 
     setState(() {

--- a/lib/screens/5_send/send_screen.dart
+++ b/lib/screens/5_send/send_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
@@ -7,6 +8,7 @@ import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';
 import '../../core/utils/formatters.dart';
+import '../../core/utils/keyset_debug.dart';
 import '../../widgets/common/gradient_background.dart';
 import '../../widgets/common/glass_card.dart';
 import '../../widgets/common/primary_button.dart';
@@ -572,8 +574,29 @@ class _SendScreenState extends State<SendScreen> {
         });
         return;
       }
+      // Offline: verificar monto mínimo con ppk del keyset local (fallback 100)
+      var ppk = await KeysetDebug.getInputFeePpk(mintUrl, _activeUnit);
+      if (ppk < 0) ppk = 100;
+      final minReceiveFee = ppk > 0 ? BigInt.from((ppk + 999) ~/ 1000) : BigInt.zero;
+      if (!mounted) return;
+      if (_amount <= minReceiveFee) {
+        setState(() {
+          _errorMessage = L10n.of(context)!.feeExceedsAmount;
+        });
+        return;
+      }
       // Offline: ir directo a selección de monedas
       _goToOfflineModeWithMessage();
+      return;
+    }
+
+    // Online: verificar monto mínimo con ppk real del mint
+    final minReceiveFee = await _getMinReceiveFee(mintUrl);
+    if (!mounted) return;
+    if (_amount <= minReceiveFee) {
+      setState(() {
+        _errorMessage = L10n.of(context)!.feeExceedsAmount;
+      });
       return;
     }
 
@@ -593,6 +616,32 @@ class _SendScreenState extends State<SendScreen> {
         onCancel: () => Navigator.pop(context),
       ),
     );
+  }
+
+  /// Calcula el fee mínimo que el receptor pagará al reclamar el token.
+  /// Consulta /v1/keysets del mint para obtener el ppk real.
+  /// Fallback: ppk=100 (estándar) → fee mínimo = 1 sat.
+  Future<BigInt> _getMinReceiveFee(String mintUrl) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$mintUrl/v1/keysets'),
+      ).timeout(const Duration(seconds: 3));
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final keysets = data['keysets'] as List<dynamic>? ?? [];
+        for (final ks in keysets) {
+          if (ks['active'] == true && ks['unit'] == _activeUnit) {
+            final ppk = (ks['input_fee_ppk'] as num?)?.toInt() ?? 0;
+            if (ppk > 0) {
+              return BigInt.from((ppk + 999) ~/ 1000); // ceil(ppk / 1000)
+            }
+            return BigInt.zero;
+          }
+        }
+      }
+    } catch (_) {}
+    // Fallback: ppk=100 estándar
+    return BigInt.one;
   }
 
   /// Verifica conectividad haciendo petición HTTP real al mint.

--- a/lib/screens/7_melt/amount_screen.dart
+++ b/lib/screens/7_melt/amount_screen.dart
@@ -404,6 +404,8 @@ class _AmountScreenState extends State<AmountScreen> {
   Future<void> _processPayment() async {
     if (!_canPay) return;
 
+    final walletProvider = context.read<WalletProvider>();
+
     setState(() {
       _isProcessing = true;
       _errorMessage = null;
@@ -431,14 +433,22 @@ class _AmountScreenState extends State<AmountScreen> {
       if (!mounted) return;
 
       // 3. Obtener quote del mint (en la unidad del mint)
-      final walletProvider = context.read<WalletProvider>();
       final quote = await walletProvider.getMeltQuote(invoiceResult.invoice);
 
       if (!mounted) return;
 
       final total = quote.amount + quote.feeReserve;
 
-      // 4. Verificar balance suficiente
+      // 4a. Verificar que el fee no supere el monto (operación inviable)
+      if (quote.amount <= quote.feeReserve) {
+        setState(() {
+          _isProcessing = false;
+          _errorMessage = L10n.of(context)!.feeExceedsAmount;
+        });
+        return;
+      }
+
+      // 4b. Verificar balance suficiente
       if (total > _availableBalance) {
         setState(() {
           _isProcessing = false;

--- a/lib/screens/8_settings/recover_tokens_modal.dart
+++ b/lib/screens/8_settings/recover_tokens_modal.dart
@@ -587,7 +587,20 @@ class _RecoverTokensModalState extends State<RecoverTokensModal> {
             if (hasRecovered) mintsRecovered++;
           }
 
+          // Recuperar proofs pendientes (sends no reclamados, melts fallidos)
+          final reclaim = await walletProvider.reclaimPendingProofs();
+
           if (!mounted) return;
+
+          // Sumar monto del reclaim a los detalles de recuperación
+          if (reclaim.count > BigInt.zero) {
+            final activeUnit = walletProvider.activeUnit;
+            final formatted = UnitFormatter.formatBalance(reclaim.amount, activeUnit);
+            final label = UnitFormatter.getUnitLabel(activeUnit);
+            recoveredDetails.add('$formatted $label (${reclaim.count} proofs)');
+            mintsRecovered++;
+          }
+
           setState(() {
             _isSuccess = true;
             if (recoveredDetails.isNotEmpty) {
@@ -624,7 +637,19 @@ class _RecoverTokensModalState extends State<RecoverTokensModal> {
             }
           }
 
+          // Recuperar proofs pendientes de este mint
+          final reclaim = await walletProvider.reclaimPendingProofs(mintUrl: _selectedMintUrl);
+
           if (!mounted) return;
+
+          // Sumar monto del reclaim a los detalles
+          if (reclaim.count > BigInt.zero) {
+            final activeUnit = walletProvider.activeUnit;
+            final formatted = UnitFormatter.formatBalance(reclaim.amount, activeUnit);
+            final label = UnitFormatter.getUnitLabel(activeUnit);
+            recoveredDetails.add('$formatted $label (${reclaim.count} proofs)');
+          }
+
           setState(() {
             _isSuccess = true;
             if (recoveredDetails.isNotEmpty) {

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -13,6 +13,25 @@ import 'token.dart';
 // These functions are ignored because they are not marked as `pub`: `mint_url`, `unit`, `update_balance_streams`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `cmp`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `into`, `partial_cmp`, `try_into`, `try_into`
 
+// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>
+abstract class PreparedMelt implements RustOpaqueInterface {
+  BigInt get amount;
+
+  BigInt get feeReserve;
+
+  BigInt get inputFee;
+
+  BigInt get swapFee;
+
+  set amount(BigInt amount);
+
+  set feeReserve(BigInt feeReserve);
+
+  set inputFee(BigInt inputFee);
+
+  set swapFee(BigInt swapFee);
+}
+
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedSend>>
 abstract class PreparedSend implements RustOpaqueInterface {
   BigInt get amount;
@@ -44,11 +63,15 @@ abstract class Wallet implements RustOpaqueInterface {
 
   Future<BigInt> balance();
 
+  Future<void> cancelMelt({required PreparedMelt melt});
+
   Future<void> cancelSend({required PreparedSend send});
 
   Future<void> checkAllMintQuotes();
 
   Future<void> checkPendingTransactions();
+
+  Future<BigInt> confirmMelt({required PreparedMelt melt});
 
   /// Create a NUT-18 payment request with Nostr transport.
   ///
@@ -66,8 +89,6 @@ abstract class Wallet implements RustOpaqueInterface {
   Future<bool> isTokenSpent({required Token token});
 
   Future<List<Transaction>> listTransactions({TransactionDirection? direction});
-
-  Future<BigInt> melt({required MeltQuote quote});
 
   Future<MeltQuote> meltQuote({required String request});
 
@@ -97,13 +118,15 @@ abstract class Wallet implements RustOpaqueInterface {
     BigInt? customAmount,
   });
 
+  Future<PreparedMelt> prepareMelt({required MeltQuote quote});
+
   Future<PreparedSend> prepareSend({required BigInt amount, SendOptions? opts});
 
   Future<BigInt> receive({required Token token, ReceiveOptions? opts});
 
   /// Check pending-spent proofs with the mint and revert unspent ones.
-  /// Returns the number of proofs recovered.
-  Future<BigInt> reclaimPendingProofs();
+  /// Returns count and total amount of proofs recovered.
+  Future<ReclaimResult> reclaimPendingProofs();
 
   Future<void> recoverIncompleteSagas();
 
@@ -182,7 +205,7 @@ class MintQuote {
   final Token? token;
   final String? error;
 
-  /// Deterministic transaction ID (set when state == Issued)
+  /// Deterministic transaction ID (set when proofs are available, typically on Issued)
   final String? transactionId;
 
   const MintQuote({
@@ -243,6 +266,24 @@ class ReceiveOptions {
           runtimeType == other.runtimeType &&
           signingKeys == other.signingKeys &&
           preimages == other.preimages;
+}
+
+class ReclaimResult {
+  final BigInt count;
+  final BigInt amount;
+
+  const ReclaimResult({required this.count, required this.amount});
+
+  @override
+  int get hashCode => count.hashCode ^ amount.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ReclaimResult &&
+          runtimeType == other.runtimeType &&
+          count == other.count &&
+          amount == other.amount;
 }
 
 class SendOptions {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -69,7 +69,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1802776128;
+  int get rustContentHash => 1903109516;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -115,6 +115,42 @@ abstract class RustLibApi extends BaseApi {
 
   PersistedRequestData crateApiPaymentRequestNostrListenerHandleToPersisted({
     required NostrListenerHandle that,
+  });
+
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetAmount({
+    required PreparedMelt that,
+  });
+
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetFeeReserve({
+    required PreparedMelt that,
+  });
+
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetInputFee({
+    required PreparedMelt that,
+  });
+
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetSwapFee({
+    required PreparedMelt that,
+  });
+
+  void crateApiWalletPreparedMeltAutoAccessorSetAmount({
+    required PreparedMelt that,
+    required BigInt amount,
+  });
+
+  void crateApiWalletPreparedMeltAutoAccessorSetFeeReserve({
+    required PreparedMelt that,
+    required BigInt feeReserve,
+  });
+
+  void crateApiWalletPreparedMeltAutoAccessorSetInputFee({
+    required PreparedMelt that,
+    required BigInt inputFee,
+  });
+
+  void crateApiWalletPreparedMeltAutoAccessorSetSwapFee({
+    required PreparedMelt that,
+    required BigInt swapFee,
   });
 
   BigInt crateApiWalletPreparedSendAutoAccessorGetAmount({
@@ -198,6 +234,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<BigInt> crateApiWalletWalletBalance({required Wallet that});
 
+  Future<void> crateApiWalletWalletCancelMelt({
+    required Wallet that,
+    required PreparedMelt melt,
+  });
+
   Future<void> crateApiWalletWalletCancelSend({
     required Wallet that,
     required PreparedSend send,
@@ -207,6 +248,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiWalletWalletCheckPendingTransactions({
     required Wallet that,
+  });
+
+  Future<BigInt> crateApiWalletWalletConfirmMelt({
+    required Wallet that,
+    required PreparedMelt melt,
   });
 
   Future<CreatedPaymentRequest> crateApiWalletWalletCreatePaymentRequest({
@@ -226,11 +272,6 @@ abstract class RustLibApi extends BaseApi {
   Future<List<Transaction>> crateApiWalletWalletListTransactions({
     required Wallet that,
     TransactionDirection? direction,
-  });
-
-  Future<BigInt> crateApiWalletWalletMelt({
-    required Wallet that,
-    required MeltQuote quote,
   });
 
   Future<MeltQuote> crateApiWalletWalletMeltQuote({
@@ -258,6 +299,11 @@ abstract class RustLibApi extends BaseApi {
     BigInt? customAmount,
   });
 
+  Future<PreparedMelt> crateApiWalletWalletPrepareMelt({
+    required Wallet that,
+    required MeltQuote quote,
+  });
+
   Future<PreparedSend> crateApiWalletWalletPrepareSend({
     required Wallet that,
     required BigInt amount,
@@ -270,7 +316,7 @@ abstract class RustLibApi extends BaseApi {
     ReceiveOptions? opts,
   });
 
-  Future<BigInt> crateApiWalletWalletReclaimPendingProofs({
+  Future<ReclaimResult> crateApiWalletWalletReclaimPendingProofs({
     required Wallet that,
   });
 
@@ -349,6 +395,14 @@ abstract class RustLibApi extends BaseApi {
 
   CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_NostrListenerHandlePtr;
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_PreparedMelt;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_PreparedMelt;
+
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_PreparedMeltPtr;
 
   RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_PreparedSend;
@@ -665,6 +719,270 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetAmount({
+    required PreparedMelt that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPreparedMeltAutoAccessorGetAmountConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPreparedMeltAutoAccessorGetAmountConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_get_amount",
+        argNames: ["that"],
+      );
+
+  @override
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetFeeReserve({
+    required PreparedMelt that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateApiWalletPreparedMeltAutoAccessorGetFeeReserveConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreparedMeltAutoAccessorGetFeeReserveConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_get_fee_reserve",
+        argNames: ["that"],
+      );
+
+  @override
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetInputFee({
+    required PreparedMelt that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPreparedMeltAutoAccessorGetInputFeeConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreparedMeltAutoAccessorGetInputFeeConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_get_input_fee",
+        argNames: ["that"],
+      );
+
+  @override
+  BigInt crateApiWalletPreparedMeltAutoAccessorGetSwapFee({
+    required PreparedMelt that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPreparedMeltAutoAccessorGetSwapFeeConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreparedMeltAutoAccessorGetSwapFeeConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_get_swap_fee",
+        argNames: ["that"],
+      );
+
+  @override
+  void crateApiWalletPreparedMeltAutoAccessorSetAmount({
+    required PreparedMelt that,
+    required BigInt amount,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          sse_encode_u_64(amount, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPreparedMeltAutoAccessorSetAmountConstMeta,
+        argValues: [that, amount],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPreparedMeltAutoAccessorSetAmountConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_set_amount",
+        argNames: ["that", "amount"],
+      );
+
+  @override
+  void crateApiWalletPreparedMeltAutoAccessorSetFeeReserve({
+    required PreparedMelt that,
+    required BigInt feeReserve,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          sse_encode_u_64(feeReserve, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateApiWalletPreparedMeltAutoAccessorSetFeeReserveConstMeta,
+        argValues: [that, feeReserve],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreparedMeltAutoAccessorSetFeeReserveConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_set_fee_reserve",
+        argNames: ["that", "feeReserve"],
+      );
+
+  @override
+  void crateApiWalletPreparedMeltAutoAccessorSetInputFee({
+    required PreparedMelt that,
+    required BigInt inputFee,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          sse_encode_u_64(inputFee, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPreparedMeltAutoAccessorSetInputFeeConstMeta,
+        argValues: [that, inputFee],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreparedMeltAutoAccessorSetInputFeeConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_set_input_fee",
+        argNames: ["that", "inputFee"],
+      );
+
+  @override
+  void crateApiWalletPreparedMeltAutoAccessorSetSwapFee({
+    required PreparedMelt that,
+    required BigInt swapFee,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            that,
+            serializer,
+          );
+          sse_encode_u_64(swapFee, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPreparedMeltAutoAccessorSetSwapFeeConstMeta,
+        argValues: [that, swapFee],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreparedMeltAutoAccessorSetSwapFeeConstMeta =>
+      const TaskConstMeta(
+        debugName: "PreparedMelt_auto_accessor_set_swap_fee",
+        argNames: ["that", "swapFee"],
+      );
+
+  @override
   BigInt crateApiWalletPreparedSendAutoAccessorGetAmount({
     required PreparedSend that,
   }) {
@@ -676,7 +994,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -707,7 +1025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -738,7 +1056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -770,7 +1088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -804,7 +1122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(amount, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -837,7 +1155,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(fee, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -870,7 +1188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(sendFee, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -904,7 +1222,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(swapFee, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -934,7 +1252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -959,7 +1277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -990,7 +1308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(input, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1019,7 +1337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_token,
@@ -1047,7 +1365,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1080,7 +1398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(path, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1111,7 +1429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1150,7 +1468,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1181,7 +1499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1210,7 +1528,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1243,7 +1561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(mintUrl, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1276,7 +1594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(unit, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1308,7 +1626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1325,6 +1643,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiWalletWalletBalanceConstMeta =>
       const TaskConstMeta(debugName: "Wallet_balance", argNames: ["that"]);
+
+  @override
+  Future<void> crateApiWalletWalletCancelMelt({
+    required Wallet that,
+    required PreparedMelt melt,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWallet(
+            that,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            melt,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 38,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateApiWalletWalletCancelMeltConstMeta,
+        argValues: [that, melt],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletWalletCancelMeltConstMeta =>
+      const TaskConstMeta(
+        debugName: "Wallet_cancel_melt",
+        argNames: ["that", "melt"],
+      );
 
   @override
   Future<void> crateApiWalletWalletCancelSend({
@@ -1346,7 +1705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1380,7 +1739,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1416,7 +1775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1438,6 +1797,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<BigInt> crateApiWalletWalletConfirmMelt({
+    required Wallet that,
+    required PreparedMelt melt,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWallet(
+            that,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+            melt,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 42,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateApiWalletWalletConfirmMeltConstMeta,
+        argValues: [that, melt],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletWalletConfirmMeltConstMeta =>
+      const TaskConstMeta(
+        debugName: "Wallet_confirm_melt",
+        argNames: ["that", "melt"],
+      );
+
+  @override
   Future<CreatedPaymentRequest> crateApiWalletWalletCreatePaymentRequest({
     required Wallet that,
     required CreateRequestParams params,
@@ -1454,7 +1854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1491,7 +1891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1525,7 +1925,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1560,7 +1960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1601,7 +2001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 47,
             port: port_,
           );
         },
@@ -1623,43 +2023,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<BigInt> crateApiWalletWalletMelt({
-    required Wallet that,
-    required MeltQuote quote,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWallet(
-            that,
-            serializer,
-          );
-          sse_encode_box_autoadd_melt_quote(quote, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 38,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_u_64,
-          decodeErrorData: sse_decode_error,
-        ),
-        constMeta: kCrateApiWalletWalletMeltConstMeta,
-        argValues: [that, quote],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletWalletMeltConstMeta => const TaskConstMeta(
-    debugName: "Wallet_melt",
-    argNames: ["that", "quote"],
-  );
-
-  @override
   Future<MeltQuote> crateApiWalletWalletMeltQuote({
     required Wallet that,
     required String request,
@@ -1676,7 +2039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 48,
             port: port_,
           );
         },
@@ -1719,7 +2082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 40,
+              funcId: 49,
               port: port_,
             );
           },
@@ -1761,7 +2124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             db,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1799,7 +2162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 51,
             port: port_,
           );
         },
@@ -1821,6 +2184,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<PreparedMelt> crateApiWalletWalletPrepareMelt({
+    required Wallet that,
+    required MeltQuote quote,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWallet(
+            that,
+            serializer,
+          );
+          sse_encode_box_autoadd_melt_quote(quote, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 52,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt,
+          decodeErrorData: sse_decode_error,
+        ),
+        constMeta: kCrateApiWalletWalletPrepareMeltConstMeta,
+        argValues: [that, quote],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletWalletPrepareMeltConstMeta =>
+      const TaskConstMeta(
+        debugName: "Wallet_prepare_melt",
+        argNames: ["that", "quote"],
+      );
+
+  @override
   Future<PreparedSend> crateApiWalletWalletPrepareSend({
     required Wallet that,
     required BigInt amount,
@@ -1839,7 +2241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 53,
             port: port_,
           );
         },
@@ -1880,7 +2282,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 54,
             port: port_,
           );
         },
@@ -1902,7 +2304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<BigInt> crateApiWalletWalletReclaimPendingProofs({
+  Future<ReclaimResult> crateApiWalletWalletReclaimPendingProofs({
     required Wallet that,
   }) {
     return handler.executeNormal(
@@ -1916,12 +2318,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 55,
             port: port_,
           );
         },
         codec: SseCodec(
-          decodeSuccessData: sse_decode_u_64,
+          decodeSuccessData: sse_decode_reclaim_result,
           decodeErrorData: sse_decode_error,
         ),
         constMeta: kCrateApiWalletWalletReclaimPendingProofsConstMeta,
@@ -1952,7 +2354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 56,
             port: port_,
           );
         },
@@ -1986,7 +2388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2028,7 +2430,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2064,7 +2466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 49,
+              funcId: 59,
               port: port_,
             );
           },
@@ -2110,7 +2512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 50,
+              funcId: 60,
               port: port_,
             );
           },
@@ -2148,7 +2550,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(proofsJson, serializer);
           sse_encode_opt_String(memo, serializer);
           sse_encode_opt_String(unit, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_token,
@@ -2178,7 +2580,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_token(token, serializer);
           sse_encode_opt_box_autoadd_usize(maxFragmentLength, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -2208,7 +2610,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2232,7 +2634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2258,7 +2660,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2283,7 +2685,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(secret, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2306,7 +2708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2333,7 +2735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(encoded, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_payment_request_info,
@@ -2362,7 +2764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2389,7 +2791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2416,7 +2818,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2441,7 +2843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(raw, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_token,
@@ -2464,7 +2866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(encoded, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_token,
@@ -2495,6 +2897,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RustArcDecrementStrongCountFnType
   get rust_arc_decrement_strong_count_NostrListenerHandle => wire
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle;
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_PreparedMelt => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_PreparedMelt => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt;
 
   RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_PreparedSend => wire
@@ -2553,6 +2963,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PreparedMelt
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
   PreparedSend
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     dynamic raw,
@@ -2598,6 +3017,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PreparedMelt
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
   PreparedSend
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     dynamic raw,
@@ -2640,6 +3068,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NostrListenerHandleImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  PreparedMelt
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -2704,6 +3141,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NostrListenerHandleImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  PreparedMelt
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -3269,6 +3715,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ReclaimResult dco_decode_reclaim_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return ReclaimResult(
+      count: dco_decode_u_64(arr[0]),
+      amount: dco_decode_u_64(arr[1]),
+    );
+  }
+
+  @protected
   (String, String) dco_decode_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3426,6 +3884,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PreparedMelt
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   PreparedSend
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     SseDeserializer deserializer,
@@ -3486,6 +3956,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PreparedMelt
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   PreparedSend
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     SseDeserializer deserializer,
@@ -3540,6 +4022,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return NostrListenerHandleImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
+  PreparedMelt
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalSseDecode(
       sse_decode_usize(deserializer),
       sse_decode_i_32(deserializer),
     );
@@ -3621,6 +4115,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return NostrListenerHandleImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
+  PreparedMelt
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return PreparedMeltImpl.frbInternalSseDecode(
       sse_decode_usize(deserializer),
       sse_decode_i_32(deserializer),
     );
@@ -4377,6 +4883,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ReclaimResult sse_decode_reclaim_result(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_count = sse_decode_u_64(deserializer);
+    var var_amount = sse_decode_u_64(deserializer);
+    return ReclaimResult(count: var_count, amount: var_amount);
+  }
+
+  @protected
   (String, String) sse_decode_record_string_string(
     SseDeserializer deserializer,
   ) {
@@ -4541,6 +5055,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as PreparedMeltImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     PreparedSend self,
     SseSerializer serializer,
@@ -4606,6 +5133,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as PreparedMeltImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     PreparedSend self,
     SseSerializer serializer,
@@ -4665,6 +5205,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
       (self as NostrListenerHandleImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as PreparedMeltImpl).frbInternalSseEncode(move: false),
       serializer,
     );
   }
@@ -4755,6 +5308,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
       (self as NostrListenerHandleImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as PreparedMeltImpl).frbInternalSseEncode(move: null),
       serializer,
     );
   }
@@ -5473,6 +6039,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_reclaim_result(ReclaimResult self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.count, serializer);
+    sse_encode_u_64(self.amount, serializer);
+  }
+
+  @protected
   void sse_encode_record_string_string(
     (String, String) self,
     SseSerializer serializer,
@@ -5677,6 +6250,62 @@ class NostrListenerHandleImpl extends RustOpaque
 }
 
 @sealed
+class PreparedMeltImpl extends RustOpaque implements PreparedMelt {
+  // Not to be used by end users
+  PreparedMeltImpl.frbInternalDcoDecode(List<dynamic> wire)
+    : super.frbInternalDcoDecode(wire, _kStaticData);
+
+  // Not to be used by end users
+  PreparedMeltImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+
+  static final _kStaticData = RustArcStaticData(
+    rustArcIncrementStrongCount:
+        RustLib.instance.api.rust_arc_increment_strong_count_PreparedMelt,
+    rustArcDecrementStrongCount:
+        RustLib.instance.api.rust_arc_decrement_strong_count_PreparedMelt,
+    rustArcDecrementStrongCountPtr:
+        RustLib.instance.api.rust_arc_decrement_strong_count_PreparedMeltPtr,
+  );
+
+  BigInt get amount => RustLib.instance.api
+      .crateApiWalletPreparedMeltAutoAccessorGetAmount(that: this);
+
+  BigInt get feeReserve => RustLib.instance.api
+      .crateApiWalletPreparedMeltAutoAccessorGetFeeReserve(that: this);
+
+  BigInt get inputFee => RustLib.instance.api
+      .crateApiWalletPreparedMeltAutoAccessorGetInputFee(that: this);
+
+  BigInt get swapFee => RustLib.instance.api
+      .crateApiWalletPreparedMeltAutoAccessorGetSwapFee(that: this);
+
+  set amount(BigInt amount) =>
+      RustLib.instance.api.crateApiWalletPreparedMeltAutoAccessorSetAmount(
+        that: this,
+        amount: amount,
+      );
+
+  set feeReserve(BigInt feeReserve) =>
+      RustLib.instance.api.crateApiWalletPreparedMeltAutoAccessorSetFeeReserve(
+        that: this,
+        feeReserve: feeReserve,
+      );
+
+  set inputFee(BigInt inputFee) =>
+      RustLib.instance.api.crateApiWalletPreparedMeltAutoAccessorSetInputFee(
+        that: this,
+        inputFee: inputFee,
+      );
+
+  set swapFee(BigInt swapFee) =>
+      RustLib.instance.api.crateApiWalletPreparedMeltAutoAccessorSetSwapFee(
+        that: this,
+        swapFee: swapFee,
+      );
+}
+
+@sealed
 class PreparedSendImpl extends RustOpaque implements PreparedSend {
   // Not to be used by end users
   PreparedSendImpl.frbInternalDcoDecode(List<dynamic> wire)
@@ -5821,6 +6450,9 @@ class WalletImpl extends RustOpaque implements Wallet {
   Future<BigInt> balance() =>
       RustLib.instance.api.crateApiWalletWalletBalance(that: this);
 
+  Future<void> cancelMelt({required PreparedMelt melt}) => RustLib.instance.api
+      .crateApiWalletWalletCancelMelt(that: this, melt: melt);
+
   Future<void> cancelSend({required PreparedSend send}) => RustLib.instance.api
       .crateApiWalletWalletCancelSend(that: this, send: send);
 
@@ -5829,6 +6461,11 @@ class WalletImpl extends RustOpaque implements Wallet {
 
   Future<void> checkPendingTransactions() => RustLib.instance.api
       .crateApiWalletWalletCheckPendingTransactions(that: this);
+
+  Future<BigInt> confirmMelt({required PreparedMelt melt}) => RustLib
+      .instance
+      .api
+      .crateApiWalletWalletConfirmMelt(that: this, melt: melt);
 
   /// Create a NUT-18 payment request with Nostr transport.
   ///
@@ -5858,9 +6495,6 @@ class WalletImpl extends RustOpaque implements Wallet {
     direction: direction,
   );
 
-  Future<BigInt> melt({required MeltQuote quote}) =>
-      RustLib.instance.api.crateApiWalletWalletMelt(that: this, quote: quote);
-
   Future<MeltQuote> meltQuote({required String request}) => RustLib.instance.api
       .crateApiWalletWalletMeltQuote(that: this, request: request);
 
@@ -5885,6 +6519,11 @@ class WalletImpl extends RustOpaque implements Wallet {
     customAmount: customAmount,
   );
 
+  Future<PreparedMelt> prepareMelt({required MeltQuote quote}) => RustLib
+      .instance
+      .api
+      .crateApiWalletWalletPrepareMelt(that: this, quote: quote);
+
   Future<PreparedSend> prepareSend({
     required BigInt amount,
     SendOptions? opts,
@@ -5902,8 +6541,8 @@ class WalletImpl extends RustOpaque implements Wallet {
       );
 
   /// Check pending-spent proofs with the mint and revert unspent ones.
-  /// Returns the number of proofs recovered.
-  Future<BigInt> reclaimPendingProofs() =>
+  /// Returns count and total amount of proofs recovered.
+  Future<ReclaimResult> reclaimPendingProofs() =>
       RustLib.instance.api.crateApiWalletWalletReclaimPendingProofs(that: this);
 
   Future<void> recoverIncompleteSagas() => RustLib.instance.api

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -32,6 +32,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandlePtr;
 
   CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_PreparedMeltPtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMeltPtr;
+
+  CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_PreparedSendPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSendPtr;
 
@@ -59,6 +63,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    dynamic raw,
+  );
+
+  @protected
+  PreparedMelt
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     dynamic raw,
   );
 
@@ -93,6 +103,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  PreparedMelt
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    dynamic raw,
+  );
+
+  @protected
   PreparedSend
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     dynamic raw,
@@ -119,6 +135,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    dynamic raw,
+  );
+
+  @protected
+  PreparedMelt
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     dynamic raw,
   );
 
@@ -158,6 +180,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    dynamic raw,
+  );
+
+  @protected
+  PreparedMelt
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     dynamic raw,
   );
 
@@ -373,6 +401,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ReceiveOptions dco_decode_receive_options(dynamic raw);
 
   @protected
+  ReclaimResult dco_decode_reclaim_result(dynamic raw);
+
+  @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
 
   @protected
@@ -427,6 +458,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  PreparedMelt
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   PreparedSend
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     SseDeserializer deserializer,
@@ -457,6 +494,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  PreparedMelt
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   PreparedSend
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     SseDeserializer deserializer,
@@ -483,6 +526,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PreparedMelt
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     SseDeserializer deserializer,
   );
 
@@ -524,6 +573,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PreparedMelt
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     SseDeserializer deserializer,
   );
 
@@ -777,6 +832,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ReceiveOptions sse_decode_receive_options(SseDeserializer deserializer);
 
   @protected
+  ReclaimResult sse_decode_reclaim_result(SseDeserializer deserializer);
+
+  @protected
   (String, String) sse_decode_record_string_string(
     SseDeserializer deserializer,
   );
@@ -841,6 +899,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     PreparedSend self,
     SseSerializer serializer,
@@ -876,6 +941,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     PreparedSend self,
     SseSerializer serializer,
@@ -906,6 +978,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
     NostrListenerHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
     SseSerializer serializer,
   );
 
@@ -954,6 +1033,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
     NostrListenerHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
     SseSerializer serializer,
   );
 
@@ -1271,6 +1357,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_reclaim_result(ReclaimResult self, SseSerializer serializer);
+
+  @protected
   void sse_encode_record_string_string(
     (String, String) self,
     SseSerializer serializer,
@@ -1402,6 +1491,40 @@ class RustLibWire implements BaseWire {
       );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandlePtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMeltPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_elcaju_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt',
+      );
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt =
+      _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMeltPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMeltPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_elcaju_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt',
+      );
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt =
+      _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMeltPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -34,6 +34,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle;
 
   CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_PreparedMeltPtr => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt;
+
+  CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_PreparedSendPtr => wire
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend;
 
@@ -61,6 +65,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    dynamic raw,
+  );
+
+  @protected
+  PreparedMelt
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     dynamic raw,
   );
 
@@ -95,6 +105,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  PreparedMelt
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    dynamic raw,
+  );
+
+  @protected
   PreparedSend
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     dynamic raw,
@@ -121,6 +137,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    dynamic raw,
+  );
+
+  @protected
+  PreparedMelt
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     dynamic raw,
   );
 
@@ -160,6 +182,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    dynamic raw,
+  );
+
+  @protected
+  PreparedMelt
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     dynamic raw,
   );
 
@@ -375,6 +403,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ReceiveOptions dco_decode_receive_options(dynamic raw);
 
   @protected
+  ReclaimResult dco_decode_reclaim_result(dynamic raw);
+
+  @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
 
   @protected
@@ -429,6 +460,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  PreparedMelt
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   PreparedSend
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     SseDeserializer deserializer,
@@ -459,6 +496,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  PreparedMelt
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   PreparedSend
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     SseDeserializer deserializer,
@@ -485,6 +528,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PreparedMelt
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     SseDeserializer deserializer,
   );
 
@@ -526,6 +575,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   NostrListenerHandle
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PreparedMelt
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     SseDeserializer deserializer,
   );
 
@@ -779,6 +834,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ReceiveOptions sse_decode_receive_options(SseDeserializer deserializer);
 
   @protected
+  ReclaimResult sse_decode_reclaim_result(SseDeserializer deserializer);
+
+  @protected
   (String, String) sse_decode_record_string_string(
     SseDeserializer deserializer,
   );
@@ -843,6 +901,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     PreparedSend self,
     SseSerializer serializer,
@@ -878,6 +943,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
     PreparedSend self,
     SseSerializer serializer,
@@ -908,6 +980,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
     NostrListenerHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
     SseSerializer serializer,
   );
 
@@ -956,6 +1035,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
     NostrListenerHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    PreparedMelt self,
     SseSerializer serializer,
   );
 
@@ -1273,6 +1359,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_reclaim_result(ReclaimResult self, SseSerializer serializer);
+
+  @protected
   void sse_encode_record_string_string(
     (String, String) self,
     SseSerializer serializer,
@@ -1358,6 +1447,22 @@ class RustLibWire implements BaseWire {
     int ptr,
   ) => wasmModule
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+        ptr,
+      );
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+        ptr,
+      );
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
         ptr,
       );
 
@@ -1449,6 +1554,16 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
 
   external void
   rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrListenerHandle(
+    int ptr,
+  );
+
+  external void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+    int ptr,
+  );
+
+  external void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
     int ptr,
   );
 

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -421,15 +421,52 @@ impl Wallet {
             .into())
     }
 
-    pub async fn melt(&self, quote: MeltQuote) -> Result<u64, Error> {
-        let melted = self
+    pub async fn prepare_melt(&self, quote: MeltQuote) -> Result<PreparedMelt, Error> {
+        let prepared = self
             .inner
             .prepare_melt(&quote.id, HashMap::new())
-            .await?
-            .confirm()
+            .await?;
+        Ok(PreparedMelt {
+            amount: prepared.amount().into(),
+            fee_reserve: prepared.quote().fee_reserve.into(),
+            swap_fee: prepared.swap_fee().into(),
+            input_fee: prepared.input_fee().into(),
+            operation_id: prepared.operation_id(),
+            cdk_quote: prepared.quote().clone(),
+            proofs: prepared.proofs().clone(),
+            proofs_to_swap: prepared.proofs_to_swap().clone(),
+            cdk_input_fee: prepared.input_fee(),
+            cdk_input_fee_without_swap: prepared.input_fee_without_swap(),
+        })
+    }
+
+    pub async fn confirm_melt(&self, melt: PreparedMelt) -> Result<u64, Error> {
+        let finalized = self
+            .inner
+            .confirm_prepared_melt(
+                melt.operation_id,
+                melt.cdk_quote,
+                melt.proofs,
+                melt.proofs_to_swap,
+                melt.cdk_input_fee,
+                melt.cdk_input_fee_without_swap,
+                HashMap::new(),
+            )
             .await?;
         self.update_balance_streams().await;
-        Ok(melted.total_amount().into())
+        Ok(finalized.total_amount().into())
+    }
+
+    pub async fn cancel_melt(&self, melt: PreparedMelt) -> Result<(), Error> {
+        self.inner
+            .cancel_prepared_melt(
+                melt.operation_id,
+                melt.proofs,
+                melt.proofs_to_swap,
+            )
+            .await?;
+        self.update_balance_streams().await;
+        Ok(())
     }
 
     // === Transactions ===
@@ -494,11 +531,19 @@ impl Wallet {
     // === Reclaim orphaned proofs ===
 
     /// Check pending-spent proofs with the mint and revert unspent ones.
-    /// Returns the number of proofs recovered.
-    pub async fn reclaim_pending_proofs(&self) -> Result<u64, Error> {
+    /// Returns count and total amount of proofs recovered.
+    pub async fn reclaim_pending_proofs(&self) -> Result<ReclaimResult, Error> {
         let pending = self.inner.get_pending_spent_proofs().await?;
         if pending.is_empty() {
-            return Ok(0);
+            return Ok(ReclaimResult { count: 0, amount: 0 });
+        }
+
+        // Build a map of Y → amount for later lookup
+        let mut amount_by_y: HashMap<PublicKey, u64> = HashMap::new();
+        for proof in &pending {
+            if let Ok(y) = proof.y() {
+                amount_by_y.insert(y, u64::from(proof.amount));
+            }
         }
 
         // check_proofs_spent: queries mint AND removes spent proofs from local DB
@@ -514,6 +559,10 @@ impl Wallet {
             .collect();
 
         let count = unspent_ys.len() as u64;
+        let amount: u64 = unspent_ys.iter()
+            .filter_map(|y| amount_by_y.get(y))
+            .sum();
+
         if count > 0 {
             // Revert from PendingSpent to Unspent
             self.inner.unreserve_proofs(unspent_ys).await?;
@@ -521,7 +570,7 @@ impl Wallet {
 
         // Always refresh: check_proofs_spent may have removed spent proofs
         self.update_balance_streams().await;
-        Ok(count)
+        Ok(ReclaimResult { count, amount })
     }
 
     // === Utility ===
@@ -675,6 +724,25 @@ impl<'a> From<CdkPreparedSend<'a>> for PreparedSend {
             cdk_send_fee: send_fee,
         }
     }
+}
+
+pub struct ReclaimResult {
+    pub count: u64,
+    pub amount: u64,
+}
+
+pub struct PreparedMelt {
+    pub amount: u64,
+    pub fee_reserve: u64,
+    pub swap_fee: u64,
+    pub input_fee: u64,
+
+    operation_id: Uuid,
+    cdk_quote: CdkMeltQuote,
+    proofs: cdk::nuts::Proofs,
+    proofs_to_swap: cdk::nuts::Proofs,
+    cdk_input_fee: Amount,
+    cdk_input_fee_without_swap: Amount,
 }
 
 #[derive(Default)]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1802776128;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1903109516;
 
 // Section: executor
 
@@ -416,6 +416,394 @@ fn wire__crate__api__payment_request__NostrListenerHandle_to_persisted_impl(
                         &*api_that_guard,
                     ),
                 )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_get_amount_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_get_amount",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(api_that_guard.amount.clone())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_get_fee_reserve_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_get_fee_reserve",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(api_that_guard.fee_reserve.clone())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_get_input_fee_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_get_input_fee",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(api_that_guard.input_fee.clone())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_get_swap_fee_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_get_swap_fee",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(api_that_guard.swap_fee.clone())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_set_amount_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_set_amount",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            let api_amount = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, true,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
+                        _ => unreachable!(),
+                    }
+                }
+                let mut api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok({
+                    {
+                        api_that_guard.amount = api_amount;
+                    };
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_set_fee_reserve_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_set_fee_reserve",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            let api_fee_reserve = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, true,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
+                        _ => unreachable!(),
+                    }
+                }
+                let mut api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok({
+                    {
+                        api_that_guard.fee_reserve = api_fee_reserve;
+                    };
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_set_input_fee_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_set_input_fee",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            let api_input_fee = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, true,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
+                        _ => unreachable!(),
+                    }
+                }
+                let mut api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok({
+                    {
+                        api_that_guard.input_fee = api_input_fee;
+                    };
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__wallet__PreparedMelt_auto_accessor_set_swap_fee_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "PreparedMelt_auto_accessor_set_swap_fee",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
+            >>::sse_decode(&mut deserializer);
+            let api_swap_fee = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, true,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
+                        _ => unreachable!(),
+                    }
+                }
+                let mut api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok({
+                    {
+                        api_that_guard.swap_fee = api_swap_fee;
+                    };
+                })?;
                 Ok(output_ok)
             })())
         },
@@ -1424,6 +1812,64 @@ fn wire__crate__api__wallet__Wallet_balance_impl(
         },
     )
 }
+fn wire__crate__api__wallet__Wallet_cancel_melt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "Wallet_cancel_melt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Wallet>,
+            >>::sse_decode(&mut deserializer);
+            let api_melt = <PreparedMelt>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::error::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok =
+                            crate::api::wallet::Wallet::cancel_melt(&*api_that_guard, api_melt)
+                                .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__Wallet_cancel_send_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1589,6 +2035,64 @@ fn wire__crate__api__wallet__Wallet_check_pending_transactions_impl(
                             &*api_that_guard,
                         )
                         .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__Wallet_confirm_melt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "Wallet_confirm_melt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Wallet>,
+            >>::sse_decode(&mut deserializer);
+            let api_melt = <PreparedMelt>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::error::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok =
+                            crate::api::wallet::Wallet::confirm_melt(&*api_that_guard, api_melt)
+                                .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1890,63 +2394,6 @@ fn wire__crate__api__wallet__Wallet_list_transactions_impl(
         },
     )
 }
-fn wire__crate__api__wallet__Wallet_melt_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "Wallet_melt",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Wallet>,
-            >>::sse_decode(&mut deserializer);
-            let api_quote = <crate::api::wallet::MeltQuote>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::error::Error>(
-                    (move || async move {
-                        let mut api_that_guard = None;
-                        let decode_indices_ =
-                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
-                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                    &api_that, 0, false,
-                                )],
-                            );
-                        for i in decode_indices_ {
-                            match i {
-                                0 => {
-                                    api_that_guard =
-                                        Some(api_that.lockable_decode_async_ref().await)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        let api_that_guard = api_that_guard.unwrap();
-                        let output_ok =
-                            crate::api::wallet::Wallet::melt(&*api_that_guard, api_quote).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__api__wallet__Wallet_melt_quote_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2182,6 +2629,64 @@ fn wire__crate__api__wallet__Wallet_pay_payment_request_impl(
                             api_custom_amount,
                         )
                         .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__Wallet_prepare_melt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "Wallet_prepare_melt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Wallet>,
+            >>::sse_decode(&mut deserializer);
+            let api_quote = <crate::api::wallet::MeltQuote>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::error::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok =
+                            crate::api::wallet::Wallet::prepare_melt(&*api_that_guard, api_quote)
+                                .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -3109,6 +3614,9 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrListenerHandle>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>
+);
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedSend>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
@@ -3146,6 +3654,16 @@ impl SseDecode for NostrListenerHandle {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <RustOpaqueMoi<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrListenerHandle>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for PreparedMelt {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
     }
@@ -3213,6 +3731,16 @@ impl SseDecode
 
 impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrListenerHandle>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
+
+impl SseDecode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3929,6 +4457,18 @@ impl SseDecode for crate::api::wallet::ReceiveOptions {
     }
 }
 
+impl SseDecode for crate::api::wallet::ReclaimResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_count = <u64>::sse_decode(deserializer);
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        return crate::api::wallet::ReclaimResult {
+            count: var_count,
+            amount: var_amount,
+        };
+    }
+}
+
 impl SseDecode for (String, String) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4091,98 +4631,100 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        23 => wire__crate__api__wallet__WalletDatabase_new_instance_impl(
+        31 => wire__crate__api__wallet__WalletDatabase_new_instance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        24 => wire__crate__api__wallet__WalletDatabase_remove_mint_impl(
+        32 => wire__crate__api__wallet__WalletDatabase_remove_mint_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        29 => wire__crate__api__wallet__Wallet_balance_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__wallet__Wallet_cancel_send_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__wallet__Wallet_check_all_mint_quotes_impl(
+        37 => wire__crate__api__wallet__Wallet_balance_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__wallet__Wallet_cancel_melt_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet__Wallet_cancel_send_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__wallet__Wallet_check_all_mint_quotes_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        32 => wire__crate__api__wallet__Wallet_check_pending_transactions_impl(
+        41 => wire__crate__api__wallet__Wallet_check_pending_transactions_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__wallet__Wallet_create_payment_request_impl(
+        42 => wire__crate__api__wallet__Wallet_confirm_melt_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__wallet__Wallet_create_payment_request_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__wallet__Wallet_finalize_pending_melts_impl(
+        44 => wire__crate__api__wallet__Wallet_finalize_pending_melts_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__wallet__Wallet_get_mint_impl(port, ptr, rust_vec_len, data_len),
-        36 => {
+        45 => wire__crate__api__wallet__Wallet_get_mint_impl(port, ptr, rust_vec_len, data_len),
+        46 => {
             wire__crate__api__wallet__Wallet_is_token_spent_impl(port, ptr, rust_vec_len, data_len)
         }
-        37 => wire__crate__api__wallet__Wallet_list_transactions_impl(
+        47 => wire__crate__api__wallet__Wallet_list_transactions_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__wallet__Wallet_melt_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__wallet__Wallet_melt_quote_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet__Wallet_mint_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__wallet__Wallet_pay_payment_request_impl(
+        48 => wire__crate__api__wallet__Wallet_melt_quote_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__wallet__Wallet_mint_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__wallet__Wallet_pay_payment_request_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__wallet__Wallet_prepare_send_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__wallet__Wallet_receive_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__wallet__Wallet_reclaim_pending_proofs_impl(
+        52 => wire__crate__api__wallet__Wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__wallet__Wallet_prepare_send_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__wallet__Wallet_receive_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__wallet__Wallet_reclaim_pending_proofs_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => wire__crate__api__wallet__Wallet_recover_incomplete_sagas_impl(
+        56 => wire__crate__api__wallet__Wallet_recover_incomplete_sagas_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => wire__crate__api__wallet__Wallet_restore_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__wallet__Wallet_send_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        57 => wire__crate__api__wallet__Wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__wallet__Wallet_send_impl(port, ptr, rust_vec_len, data_len),
+        59 => {
             wire__crate__api__wallet__Wallet_stream_balance_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__wallet__Wallet_wait_for_nostr_payment_impl(
+        60 => wire__crate__api__wallet__Wallet_wait_for_nostr_payment_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__mint_info__fetch_keysets_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__mint_info__get_mint_info_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__mint_info__ping_mint_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__wallet__receive_options_default_impl(
+        63 => wire__crate__api__mint_info__fetch_keysets_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__mint_info__get_mint_info_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__mint_info__ping_mint_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__wallet__receive_options_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => {
+        71 => {
             wire__crate__api__wallet__send_options_default_impl(port, ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -4205,33 +4747,41 @@ fn pde_ffi_dispatcher_sync_impl(
 6 => wire__crate__api__payment_request__CreatedPaymentRequest_auto_accessor_set_listener_handle_impl(ptr, rust_vec_len, data_len),
 7 => wire__crate__api__payment_request__NostrListenerHandle_from_persisted_impl(ptr, rust_vec_len, data_len),
 8 => wire__crate__api__payment_request__NostrListenerHandle_to_persisted_impl(ptr, rust_vec_len, data_len),
-9 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_amount_impl(ptr, rust_vec_len, data_len),
-10 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_fee_impl(ptr, rust_vec_len, data_len),
-11 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_send_fee_impl(ptr, rust_vec_len, data_len),
-12 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_swap_fee_impl(ptr, rust_vec_len, data_len),
-13 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_amount_impl(ptr, rust_vec_len, data_len),
-14 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_fee_impl(ptr, rust_vec_len, data_len),
-15 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_send_fee_impl(ptr, rust_vec_len, data_len),
-16 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_swap_fee_impl(ptr, rust_vec_len, data_len),
-17 => wire__crate__api__token__TokenDecoder_is_complete_impl(ptr, rust_vec_len, data_len),
-18 => wire__crate__api__token__TokenDecoder_new_impl(ptr, rust_vec_len, data_len),
-19 => wire__crate__api__token__TokenDecoder_receive_impl(ptr, rust_vec_len, data_len),
-20 => wire__crate__api__token__TokenDecoder_value_impl(ptr, rust_vec_len, data_len),
-21 => wire__crate__api__wallet__WalletDatabase_auto_accessor_get_path_impl(ptr, rust_vec_len, data_len),
-22 => wire__crate__api__wallet__WalletDatabase_auto_accessor_set_path_impl(ptr, rust_vec_len, data_len),
-25 => wire__crate__api__wallet__Wallet_auto_accessor_get_mint_url_impl(ptr, rust_vec_len, data_len),
-26 => wire__crate__api__wallet__Wallet_auto_accessor_get_unit_impl(ptr, rust_vec_len, data_len),
-27 => wire__crate__api__wallet__Wallet_auto_accessor_set_mint_url_impl(ptr, rust_vec_len, data_len),
-28 => wire__crate__api__wallet__Wallet_auto_accessor_set_unit_impl(ptr, rust_vec_len, data_len),
-41 => wire__crate__api__wallet__Wallet_new_impl(ptr, rust_vec_len, data_len),
-51 => wire__crate__api__token__create_offline_token_impl(ptr, rust_vec_len, data_len),
-52 => wire__crate__api__token__encode_qr_token_impl(ptr, rust_vec_len, data_len),
-54 => wire__crate__api__keys__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-56 => wire__crate__api__keys__get_pub_key_impl(ptr, rust_vec_len, data_len),
-57 => wire__crate__api__keys__mnemonic_to_seed_impl(ptr, rust_vec_len, data_len),
-58 => wire__crate__api__payment_request__payment_request_info_parse_impl(ptr, rust_vec_len, data_len),
-62 => wire__crate__api__token__token_from_raw_bytes_impl(ptr, rust_vec_len, data_len),
-63 => wire__crate__api__token__token_parse_impl(ptr, rust_vec_len, data_len),
+9 => wire__crate__api__wallet__PreparedMelt_auto_accessor_get_amount_impl(ptr, rust_vec_len, data_len),
+10 => wire__crate__api__wallet__PreparedMelt_auto_accessor_get_fee_reserve_impl(ptr, rust_vec_len, data_len),
+11 => wire__crate__api__wallet__PreparedMelt_auto_accessor_get_input_fee_impl(ptr, rust_vec_len, data_len),
+12 => wire__crate__api__wallet__PreparedMelt_auto_accessor_get_swap_fee_impl(ptr, rust_vec_len, data_len),
+13 => wire__crate__api__wallet__PreparedMelt_auto_accessor_set_amount_impl(ptr, rust_vec_len, data_len),
+14 => wire__crate__api__wallet__PreparedMelt_auto_accessor_set_fee_reserve_impl(ptr, rust_vec_len, data_len),
+15 => wire__crate__api__wallet__PreparedMelt_auto_accessor_set_input_fee_impl(ptr, rust_vec_len, data_len),
+16 => wire__crate__api__wallet__PreparedMelt_auto_accessor_set_swap_fee_impl(ptr, rust_vec_len, data_len),
+17 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_amount_impl(ptr, rust_vec_len, data_len),
+18 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_fee_impl(ptr, rust_vec_len, data_len),
+19 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_send_fee_impl(ptr, rust_vec_len, data_len),
+20 => wire__crate__api__wallet__PreparedSend_auto_accessor_get_swap_fee_impl(ptr, rust_vec_len, data_len),
+21 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_amount_impl(ptr, rust_vec_len, data_len),
+22 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_fee_impl(ptr, rust_vec_len, data_len),
+23 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_send_fee_impl(ptr, rust_vec_len, data_len),
+24 => wire__crate__api__wallet__PreparedSend_auto_accessor_set_swap_fee_impl(ptr, rust_vec_len, data_len),
+25 => wire__crate__api__token__TokenDecoder_is_complete_impl(ptr, rust_vec_len, data_len),
+26 => wire__crate__api__token__TokenDecoder_new_impl(ptr, rust_vec_len, data_len),
+27 => wire__crate__api__token__TokenDecoder_receive_impl(ptr, rust_vec_len, data_len),
+28 => wire__crate__api__token__TokenDecoder_value_impl(ptr, rust_vec_len, data_len),
+29 => wire__crate__api__wallet__WalletDatabase_auto_accessor_get_path_impl(ptr, rust_vec_len, data_len),
+30 => wire__crate__api__wallet__WalletDatabase_auto_accessor_set_path_impl(ptr, rust_vec_len, data_len),
+33 => wire__crate__api__wallet__Wallet_auto_accessor_get_mint_url_impl(ptr, rust_vec_len, data_len),
+34 => wire__crate__api__wallet__Wallet_auto_accessor_get_unit_impl(ptr, rust_vec_len, data_len),
+35 => wire__crate__api__wallet__Wallet_auto_accessor_set_mint_url_impl(ptr, rust_vec_len, data_len),
+36 => wire__crate__api__wallet__Wallet_auto_accessor_set_unit_impl(ptr, rust_vec_len, data_len),
+50 => wire__crate__api__wallet__Wallet_new_impl(ptr, rust_vec_len, data_len),
+61 => wire__crate__api__token__create_offline_token_impl(ptr, rust_vec_len, data_len),
+62 => wire__crate__api__token__encode_qr_token_impl(ptr, rust_vec_len, data_len),
+64 => wire__crate__api__keys__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+66 => wire__crate__api__keys__get_pub_key_impl(ptr, rust_vec_len, data_len),
+67 => wire__crate__api__keys__mnemonic_to_seed_impl(ptr, rust_vec_len, data_len),
+68 => wire__crate__api__payment_request__payment_request_info_parse_impl(ptr, rust_vec_len, data_len),
+72 => wire__crate__api__token__token_from_raw_bytes_impl(ptr, rust_vec_len, data_len),
+73 => wire__crate__api__token__token_parse_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -4272,6 +4822,21 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<NostrListenerHandle>> for NostrListenerHandle {
     fn into_into_dart(self) -> FrbWrapper<NostrListenerHandle> {
+        self.into()
+    }
+}
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<PreparedMelt> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<PreparedMelt> {}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<PreparedMelt>> for PreparedMelt {
+    fn into_into_dart(self) -> FrbWrapper<PreparedMelt> {
         self.into()
     }
 }
@@ -4784,6 +5349,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::ReceiveOptions>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::ReclaimResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.count.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::ReclaimResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::ReclaimResult>
+    for crate::api::wallet::ReclaimResult
+{
+    fn into_into_dart(self) -> crate::api::wallet::ReclaimResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::wallet::SendOptions {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -4980,6 +5566,13 @@ impl SseEncode for NostrListenerHandle {
     }
 }
 
+impl SseEncode for PreparedMelt {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+    }
+}
+
 impl SseEncode for PreparedSend {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5030,6 +5623,17 @@ impl SseEncode
 
 impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrListenerHandle>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5589,6 +6193,14 @@ impl SseEncode for crate::api::wallet::ReceiveOptions {
     }
 }
 
+impl SseEncode for crate::api::wallet::ReclaimResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.count, serializer);
+        <u64>::sse_encode(self.amount, serializer);
+    }
+}
+
 impl SseEncode for (String, String) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5766,6 +6378,20 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_elcaju_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_elcaju_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>::decrement_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_elcaju_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedSend(
         ptr: *const std::ffi::c_void,
     ) {
@@ -5874,6 +6500,20 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrListenerHandle>>::decrement_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPreparedMelt(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<PreparedMelt>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
- Expose prepare_melt/confirm_melt/cancel_melt in Rust bridge (mirrors send pattern)
- wallet_provider.melt() now cancels reserved proofs on failure
- swap_screen uses prepare/confirm/cancel directly on source wallet
- Pre-validate fee viability before melt (amount <= feeReserve)
- Validate minimum receive amount before send (online: /v1/keysets, offline: local DB)
- Add reclaimPendingProofs() to recover tokens modal for manual recovery
- ReclaimResult returns both count and amount for unified recovery messages
- Add feeExceedsAmount l10n string in 11 languages

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fee validation added to send and swap flows to block transactions where fees would exceed or equal the amount.
  * Pending-proof recovery included in token recovery results, showing reclaimed counts and amounts.
  * New localized fee-exceeded error message added across multiple languages (translations included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->