### PR TITLE
fix: reclaim orphaned proofs automatically on app startup

### DIFF
--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1733,6 +1733,13 @@ class WalletProvider extends ChangeNotifier {
             debugPrint('Check pending failed: $e');
           }
 
+          try {
+            // Recuperar proofs huérfanas (melts fallidos, sends no completados)
+            await wallet.reclaimPendingProofs();
+          } catch (e) {
+            debugPrint('Reclaim pending proofs failed: $e');
+          }
+
         } catch (e) {
           debugPrint('Error getting wallet ${entry.key}:$unit: $e');
         }


### PR DESCRIPTION
reclaimPendingProofs() was available but never called at startup, leaving proofs stuck in PendingSpent state after crashes or force-closes during melt operations. This adds it to the existing per-wallet startup checks in checkPendingTransactions().


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of orphaned proofs from incomplete transactions. Failed recovery attempts are now handled gracefully without affecting other wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->