### PR TITLE
fix: deliver mint Issued event before metadata await (closes #115)

### DIFF
--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1354,24 +1354,31 @@ class WalletProvider extends ChangeNotifier {
       amount: amount,
       description: description,
     ).listen(
-      (quote) async {
+      (quote) {
         // Guardar invoice temprano en SharedPreferences
         if (quote.state == MintQuoteState.unpaid) {
           invoiceBolt11 = quote.request;
           _savePendingMintInvoice(quote.id, quote.request, mintUrl, unit, amount);
         }
 
-        // Cuando se completa, guardar metadata, confetti, limpiar pending
-        if (quote.state == MintQuoteState.issued && invoiceBolt11 != null) {
-          final saved = await _saveMintMetadata(wallet, invoiceBolt11!, quote.transactionId);
-          // Only remove pending invoice if metadata was saved;
-          // otherwise _matchPendingMintInvoices can recover it on next startup
-          if (saved) _removePendingMintInvoice(quote.id);
-        }
-
-        // Reenviar a la UI (si sigue escuchando)
+        // Reenviar a la UI ANTES de cualquier await: Rust cierra el stream
+        // inmediatamente tras emitir Issued, y onDone corre durante el await
+        // de _saveMintMetadata, cerrando el controller antes de que el evento
+        // llegue al screen.
         if (!controller.isClosed) {
           controller.add(quote);
+        }
+
+        // Metadata async fire-and-forget (no bloquea el forward)
+        if (quote.state == MintQuoteState.issued && invoiceBolt11 != null) {
+          final invoice = invoiceBolt11!;
+          unawaited(
+            _saveMintMetadata(wallet, invoice, quote.transactionId).then((saved) {
+              // Only remove pending invoice if metadata was saved;
+              // otherwise _matchPendingMintInvoices can recover it on next startup
+              if (saved) _removePendingMintInvoice(quote.id);
+            }),
+          );
         }
       },
       onError: (error) {

--- a/lib/screens/12_request/request_screen.dart
+++ b/lib/screens/12_request/request_screen.dart
@@ -841,8 +841,7 @@ class _RequestScreenState extends State<RequestScreen> {
       _status = RequestStatus.received;
       _receivedAmount = amount;
     });
-    final walletProvider = context.read<WalletProvider>();
-    walletProvider.confettiController.fire();
+    // Confetti se dispara globalmente desde WalletProvider._saveMintMetadata
     // TODO: re-enable once CDK fixes NIP-17 (cashubtc/cdk#1807)
     // Only remove pending Nostr request if this screen created one.
     // Disabled while Nostr payment requests are disabled to avoid


### PR DESCRIPTION
The mint stream listener awaited _saveMintMetadata before forwarding the Issued event to the UI. Rust closes the stream immediately after emitting Issued, so onDone ran during the await and closed the controller before controller.add fired leaving request_screen stuck on "waiting" while confetti still triggered from the metadata save path.                                                                                                 
                                                                                                                                                      
Forward the event synchronously first, then run metadata work as fire-and-forget via unawaited(). Also remove the duplicated confetti fire from request_screen._onPaymentSuccess; the provider's _saveMintMetadata already fires it globally, matching invoice_screen's behavior.                                                                                        
                               

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced mint quote handling for faster UI responsiveness
  * Reorganized confetti animation trigger to occur globally rather than locally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->