### PR TITLE
chore(settings): align recover icon and reorder wallet section

### DIFF
--- a/lib/screens/8_settings/recover_tokens_modal.dart
+++ b/lib/screens/8_settings/recover_tokens_modal.dart
@@ -69,7 +69,7 @@ class _RecoverTokensModalState extends State<RecoverTokensModal> {
                   shape: BoxShape.circle,
                 ),
                 child: Icon(
-                  LucideIcons.refreshCw,
+                  LucideIcons.searchCode,
                   color: AppColors.primaryAction,
                   size: 32,
                 ),

--- a/lib/screens/8_settings/settings_screen.dart
+++ b/lib/screens/8_settings/settings_screen.dart
@@ -96,12 +96,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       },
                     ),
                     _buildSettingTile(
-                      icon: LucideIcons.key,
-                      title: l10n.backupSeedPhrase,
-                      subtitle: l10n.viewRecoveryWords,
-                      onTap: () => _showBackupSeed(context, settingsProvider),
-                    ),
-                    _buildSettingTile(
                       icon: LucideIcons.landmark,
                       title: l10n.connectedMints,
                       subtitle: l10n.manageCashuMints,
@@ -126,6 +120,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             _togglePin(context, settingsProvider, value),
                         activeThumbColor: AppColors.primaryAction,
                       ),
+                    ),
+                    _buildSettingTile(
+                      icon: LucideIcons.key,
+                      title: l10n.backupSeedPhrase,
+                      subtitle: l10n.viewRecoveryWords,
+                      onTap: () => _showBackupSeed(context, settingsProvider),
                     ),
                     _buildSettingTile(
                       icon: LucideIcons.searchCode,


### PR DESCRIPTION
- Use LucideIcons.searchCode (magnifier) in the recover tokens modal to match the settings list entry, replacing the refresh arrows.
- Reorder wallet section so Backup seed phrase sits next to Recover tokens (they share the same seed), and P2PK stays last as an experimental feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon in token recovery modal
  * Reordered wallet settings options for improved organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->