### PR TITLE
fix: restoreWithMnemonic returns per-unit balances instead of single BigInt

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,146 @@
+name: Build APK Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Rama a utilizar para el build (ej: main, develop, feature/xxx)"
+        required: true
+        default: "main"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-arm64:
+    name: Build ARM64 (armV8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - name: Install Android NDK
+        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.0.12077973"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Build ARM64 APK
+        run: flutter build apk --release --target-platform android-arm64
+
+      - name: Upload ARM64 APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: elcaju-arm64-v8a
+          path: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+
+  build-armv7:
+    name: Build ARMv7 (armV7)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: armv7-linux-androideabi
+
+      - name: Install Android NDK
+        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.0.12077973"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Build ARMv7 APK
+        run: flutter build apk --release --target-platform android-arm
+
+      - name: Upload ARMv7 APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: elcaju-armeabi-v7a
+          path: build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
+
+  build-x86-64:
+    name: Build x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-linux-android
+
+      - name: Install Android NDK
+        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.0.12077973"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Build x86_64 APK
+        run: flutter build apk --release --target-platform android-x64
+
+      - name: Upload x86_64 APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: elcaju-x86-64
+          path: build/app/outputs/flutter-apk/app-x86_64-release.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.0'
+          channel: stable
           cache: true
 
       - name: Cache Rust

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -7,8 +7,8 @@ permissions:
   contents: read
 
 jobs:
-  build-arm64:
-    name: Build ARM64 (armV8)
+  build:
+    name: Build all APKs
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -25,14 +25,44 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
+
+      - name: Cache Rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            rust_builder/target/
+          key: rust-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-${{ runner.os }}-
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-linux-android
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
 
       - name: Install Android NDK
         run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.0.12077973"
+
+      - name: Cache Flutter pub
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.PUB_CACHE }}
+          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
 
       - name: Install dependencies
         run: flutter pub get
@@ -40,8 +70,8 @@ jobs:
       - name: Generate localizations
         run: flutter gen-l10n
 
-      - name: Build ARM64 APK
-        run: flutter build apk --release --target-platform android-arm64
+      - name: Build all APKs (split per ABI)
+        run: flutter build apk --release --split-per-abi
 
       - name: Upload ARM64 APK
         uses: actions/upload-artifact@v4
@@ -49,83 +79,11 @@ jobs:
           name: elcaju-arm64-v8a
           path: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
 
-  build-armv7:
-    name: Build ARMv7 (armV7)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: armv7-linux-androideabi
-
-      - name: Install Android NDK
-        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.0.12077973"
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Generate localizations
-        run: flutter gen-l10n
-
-      - name: Build ARMv7 APK
-        run: flutter build apk --release --target-platform android-arm
-
       - name: Upload ARMv7 APK
         uses: actions/upload-artifact@v4
         with:
           name: elcaju-armeabi-v7a
           path: build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
-
-  build-x86-64:
-    name: Build x86_64
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-linux-android
-
-      - name: Install Android NDK
-        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.0.12077973"
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Generate localizations
-        run: flutter gen-l10n
-
-      - name: Build x86_64 APK
-        run: flutter build apk --release --target-platform android-x64
 
       - name: Upload x86_64 APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: '3.22.0'
           cache: true
 
       - name: Cache Rust

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -2,12 +2,6 @@ name: Build APK Release
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Rama a utilizar para el build (ej: main, develop, feature/xxx)"
-        required: true
-        default: "main"
-        type: string
 
 permissions:
   contents: read
@@ -20,8 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -64,8 +56,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -108,8 +98,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
 
       - name: Setup Java 17
         uses: actions/setup-java@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,4 +1,4 @@
-name: Build APK Release
+name: Build APK Release v2
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,4 +1,4 @@
-name: Build APK Release v2
+name: Build APK Release
 
 on:
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ app.*.map.json
 # Rust/CargoKit compiled native libraries
 android/app/src/main/jniLibs/
 rust/target/
+android/build/

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1946,8 +1946,8 @@ class WalletProvider extends ChangeNotifier {
   }
 
   /// Restaura tokens usando otro mnemonic y los transfiere al wallet actual.
-  /// Retorna un mapa con la unidad como clave y el balance recuperado como valor.
-  Future<Map<String, BigInt>> restoreWithMnemonic(
+  /// Retorna un mapa con el mintUrl como clave y un mapa de unit->balance como valor.
+  Future<Map<String, Map<String, BigInt>>> restoreWithMnemonic(
     String mnemonic,
     List<String> mintUrls,
   ) async {
@@ -1955,7 +1955,7 @@ class WalletProvider extends ChangeNotifier {
       throw Exception('WalletProvider no inicializado');
     }
 
-    final recoveredByUnit = <String, BigInt>{};
+    final results = <String, Map<String, BigInt>>{};
 
     // Normalizar mnemonic
     final normalizedMnemonic =
@@ -1989,21 +1989,24 @@ class WalletProvider extends ChangeNotifier {
             await tempWallet.restore();
             final tempBalance = await tempWallet.balance();
 
-            if (tempBalance > BigInt.zero) {
-              // Enviar todo el balance
-              final prepared =
-                  await tempWallet.prepareSend(amount: tempBalance);
-              final result = await tempWallet.send(
-                send: prepared,
-                memo: 'Recuperación El Caju',
-                includeMemo: true,
-              );
+            // Inicializar el mapa de unidades para este mint si no existe
+              results[mintUrl] ??= {};
+              
+              if (tempBalance > BigInt.zero) {
+                // Enviar todo el balance
+                final prepared =
+                    await tempWallet.prepareSend(amount: tempBalance);
+                final result = await tempWallet.send(
+                  send: prepared,
+                  memo: 'Recuperación El Caju',
+                  includeMemo: true,
+                );
 
-              // Reclamar en nuestro wallet
-              final ourWallet = await getWallet(mintUrl, unit);
-              final received = await ourWallet.receive(token: result.token);
-              recoveredByUnit[unit] = (recoveredByUnit[unit] ?? BigInt.zero) + received;
-            }
+                // Reclamar en nuestro wallet
+                final ourWallet = await getWallet(mintUrl, unit);
+                final received = await ourWallet.receive(token: result.token);
+                results[mintUrl]![unit] = (results[mintUrl]![unit] ?? BigInt.zero) + received;
+              }
           } catch (e) {
             debugPrint('Error restaurando $mintUrl:$unit: $e');
           }
@@ -2023,7 +2026,7 @@ class WalletProvider extends ChangeNotifier {
     }
 
     notifyListeners();
-    return recoveredByUnit;
+    return results;
   }
 
   // ============================================================

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -1946,7 +1946,8 @@ class WalletProvider extends ChangeNotifier {
   }
 
   /// Restaura tokens usando otro mnemonic y los transfiere al wallet actual.
-  Future<BigInt> restoreWithMnemonic(
+  /// Retorna un mapa con la unidad como clave y el balance recuperado como valor.
+  Future<Map<String, BigInt>> restoreWithMnemonic(
     String mnemonic,
     List<String> mintUrls,
   ) async {
@@ -1954,7 +1955,7 @@ class WalletProvider extends ChangeNotifier {
       throw Exception('WalletProvider no inicializado');
     }
 
-    BigInt totalRecovered = BigInt.zero;
+    final recoveredByUnit = <String, BigInt>{};
 
     // Normalizar mnemonic
     final normalizedMnemonic =
@@ -2001,7 +2002,7 @@ class WalletProvider extends ChangeNotifier {
               // Reclamar en nuestro wallet
               final ourWallet = await getWallet(mintUrl, unit);
               final received = await ourWallet.receive(token: result.token);
-              totalRecovered += received;
+              recoveredByUnit[unit] = (recoveredByUnit[unit] ?? BigInt.zero) + received;
             }
           } catch (e) {
             debugPrint('Error restaurando $mintUrl:$unit: $e');
@@ -2022,7 +2023,7 @@ class WalletProvider extends ChangeNotifier {
     }
 
     notifyListeners();
-    return totalRecovered;
+    return recoveredByUnit;
   }
 
   // ============================================================

--- a/lib/screens/10_scanner/scan_screen.dart
+++ b/lib/screens/10_scanner/scan_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/utils/incoming_data_parser.dart';

--- a/lib/screens/11_payment_request/payment_request_screen.dart
+++ b/lib/screens/11_payment_request/payment_request_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/12_request/request_screen.dart
+++ b/lib/screens/12_request/request_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../src/rust/api/wallet.dart';
 import '../../src/rust/api/payment_request.dart';

--- a/lib/screens/13_swap/swap_screen.dart
+++ b/lib/screens/13_swap/swap_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/2_onboarding/backup_seed_screen.dart
+++ b/lib/screens/2_onboarding/backup_seed_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/2_onboarding/create_wallet_screen.dart
+++ b/lib/screens/2_onboarding/create_wallet_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/2_onboarding/restore_wallet_screen.dart
+++ b/lib/screens/2_onboarding/restore_wallet_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/2_onboarding/welcome_screen.dart
+++ b/lib/screens/2_onboarding/welcome_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/3_home/home_screen.dart
+++ b/lib/screens/3_home/home_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/4_receive/receive_screen.dart
+++ b/lib/screens/4_receive/receive_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/5_send/offline_send_screen.dart
+++ b/lib/screens/5_send/offline_send_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../providers/wallet_provider.dart';

--- a/lib/screens/5_send/send_screen.dart
+++ b/lib/screens/5_send/send_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/5_send/share_token_screen.dart
+++ b/lib/screens/5_send/share_token_screen.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../src/rust/api/token.dart' as cdk;
 import 'package:elcaju/l10n/app_localizations.dart';

--- a/lib/screens/6_mint/invoice_screen.dart
+++ b/lib/screens/6_mint/invoice_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../src/rust/api/wallet.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';

--- a/lib/screens/6_mint/mint_screen.dart
+++ b/lib/screens/6_mint/mint_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/7_melt/amount_screen.dart
+++ b/lib/screens/7_melt/amount_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/7_melt/melt_screen.dart
+++ b/lib/screens/7_melt/melt_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../src/rust/api/wallet.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';

--- a/lib/screens/8_settings/delete_wallet_modal.dart
+++ b/lib/screens/8_settings/delete_wallet_modal.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/8_settings/language_screen.dart
+++ b/lib/screens/8_settings/language_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';

--- a/lib/screens/8_settings/mint_detail_screen.dart
+++ b/lib/screens/8_settings/mint_detail_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../src/rust/api/mint_info.dart' show MintInfo, ContactInfo;
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';

--- a/lib/screens/8_settings/mints_screen.dart
+++ b/lib/screens/8_settings/mints_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 import '../../src/rust/api/mint_info.dart' show MintInfo;
 import 'package:elcaju/l10n/app_localizations.dart';

--- a/lib/screens/8_settings/p2pk_keys_screen.dart
+++ b/lib/screens/8_settings/p2pk_keys_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import 'package:qr_flutter/qr_flutter.dart';

--- a/lib/screens/8_settings/pin_dialog.dart
+++ b/lib/screens/8_settings/pin_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../core/constants/colors.dart';
 
 /// Diálogo para ingresar PIN de 4 dígitos

--- a/lib/screens/8_settings/privacy_screen.dart
+++ b/lib/screens/8_settings/privacy_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';
 import '../../core/constants/dimensions.dart';

--- a/lib/screens/8_settings/recover_tokens_modal.dart
+++ b/lib/screens/8_settings/recover_tokens_modal.dart
@@ -668,7 +668,7 @@ class _RecoverTokensModalState extends State<RecoverTokensModal> {
           return;
         }
 
-        final recovered = await walletProvider.restoreWithMnemonic(
+        final recoveredMap = await walletProvider.restoreWithMnemonic(
           mnemonic,
           mintUrls,
         );
@@ -676,12 +676,16 @@ class _RecoverTokensModalState extends State<RecoverTokensModal> {
         if (!mounted) return;
         setState(() {
           _isSuccess = true;
-          if (recovered > BigInt.zero) {
-            // Usamos la unidad activa como aproximación para el formato
-            final activeUnit = walletProvider.activeUnit;
-            final formatted = UnitFormatter.formatBalance(recovered, activeUnit);
-            final label = UnitFormatter.getUnitLabel(activeUnit);
-            _result = l10n.recoveredAndTransferred(formatted, label);
+          final recoveredDetails = <String>[];
+          for (final entry in recoveredMap.entries) {
+            if (entry.value > BigInt.zero) {
+              final formatted = UnitFormatter.formatBalance(entry.value, entry.key);
+              final label = UnitFormatter.getUnitLabel(entry.key);
+              recoveredDetails.add('$formatted $label');
+            }
+          }
+          if (recoveredDetails.isNotEmpty) {
+            _result = l10n.recoveredTokens(recoveredDetails.join(", "), recoveredDetails.length);
           } else {
             _result = l10n.noTokensForMnemonic;
           }

--- a/lib/screens/8_settings/recover_tokens_modal.dart
+++ b/lib/screens/8_settings/recover_tokens_modal.dart
@@ -677,15 +677,24 @@ class _RecoverTokensModalState extends State<RecoverTokensModal> {
         setState(() {
           _isSuccess = true;
           final recoveredDetails = <String>[];
-          for (final entry in recoveredMap.entries) {
-            if (entry.value > BigInt.zero) {
-              final formatted = UnitFormatter.formatBalance(entry.value, entry.key);
-              final label = UnitFormatter.getUnitLabel(entry.key);
-              recoveredDetails.add('$formatted $label');
+          int mintsRecovered = 0;
+          
+          for (final mintEntry in recoveredMap.entries) {
+            final unitBalances = mintEntry.value;
+            bool hasRecovered = false;
+            for (final unitEntry in unitBalances.entries) {
+              if (unitEntry.value > BigInt.zero) {
+                final formatted = UnitFormatter.formatBalance(unitEntry.value, unitEntry.key);
+                final label = UnitFormatter.getUnitLabel(unitEntry.key);
+                recoveredDetails.add('$formatted $label');
+                hasRecovered = true;
+              }
             }
+            if (hasRecovered) mintsRecovered++;
           }
+          
           if (recoveredDetails.isNotEmpty) {
-            _result = l10n.recoveredTokens(recoveredDetails.join(", "), recoveredDetails.length);
+            _result = l10n.recoveredTokens(recoveredDetails.join(", "), mintsRecovered);
           } else {
             _result = l10n.noTokensForMnemonic;
           }

--- a/lib/screens/8_settings/recover_tokens_modal.dart
+++ b/lib/screens/8_settings/recover_tokens_modal.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../core/constants/colors.dart';

--- a/lib/screens/8_settings/settings_screen.dart
+++ b/lib/screens/8_settings/settings_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/lib/screens/8_settings/settings_screen.dart
+++ b/lib/screens/8_settings/settings_screen.dart
@@ -180,7 +180,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       ),
                     ),
                     _buildSettingTile(
-                      icon: LucideIcons.github,
+                      icon: LucideIcons.externalLink,
                       title: 'GitHub',
                       onTap: () => _openGitHub(),
                     ),

--- a/lib/screens/9_history/history_screen.dart
+++ b/lib/screens/9_history/history_screen.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:intl/intl.dart';
 import '../../src/rust/api/token.dart' as cdk;

--- a/lib/widgets/common/numpad_widget.dart
+++ b/lib/widgets/common/numpad_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../core/constants/colors.dart';
 
 /// Callback cuando el valor cambia

--- a/lib/widgets/scanner/qr_scanner_widget.dart
+++ b/lib/widgets/scanner/qr_scanner_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
-import 'package:lucide_icons/lucide_icons.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:elcaju/l10n/app_localizations.dart';
 import '../../src/rust/api/token.dart';
 import '../../core/constants/colors.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -565,14 +565,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  lucide_icons:
+  lucide_icons_flutter:
     dependency: "direct main"
     description:
-      name: lucide_icons
-      sha256: ad24d0fd65707e48add30bebada7d90bff2a1bba0a72d6e9b19d44246b0e83c4
+      name: lucide_icons_flutter
+      sha256: "234155b10641b8ef7bab8a077b93ea6c92fe849c06740cf89dcd86dcf350934f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.257.0"
+    version: "3.1.15"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   sqflite_common_ffi: ^2.3.0
 
   # Icons
-  lucide_icons: ^0.257.0
+  lucide_icons_flutter: ^3.1.15
 
   # Fonts
   google_fonts: ^6.1.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:elcaju/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const ElCajuApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- Change `restoreWithMnemonic()` return type from `BigInt` to `Map<String, BigInt>` to preserve unit information
- Update `RecoverTokensModal` to display each unit separately (e.g., "1000 sat, 5 USD, 10 EUR")
- Fix widget_test.dart to use `ElCajuApp` instead of `MyApp`
## Problem
`restoreWithMnemonic()` was returning a single `BigInt`, losing unit information. This caused incorrect display when tokens were recovered from mints with different units (sat, USD, EUR).
**Example:** Recovering 1000 sat + 5 USD would display as "1005 sat" or "1005 USD" depending on active unit.
## Solution
Now returns `Map<String, BigInt>` (unit → balance), consistent with other restore methods:
- `restoreFromMint()` → `Map<String, BigInt>`
- `restoreAllMints()` → `Map<String, Map<String, BigInt>>`
- `restoreWithMnemonic()` → `Map<String, BigInt>`
## Files Changed
- `lib/providers/wallet_provider.dart` - Change return type and accumulator
- `lib/screens/8_settings/recover_tokens_modal.dart` - Update display logic
- `test/widget_test.dart` - Fix class name
## Testing
- Linux build tested and working
- Android APK tested and working
- Per-unit balances displayed correctly
Resolves #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Token recovery now returns and displays recovered balances grouped by mint and unit, with recovery details compiled from units that have positive amounts.
  * The success screen now shows a more precise recovered-tokens message, including which units were found per mint.
* **Tests**
  * Updated the widget test to mount the current app root widget while preserving the same counter behavior.
* **Chores**
  * Added a manual release workflow to build and upload split-ABI APKs for multiple Android architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->